### PR TITLE
String localized receives bundle to use

### DIFF
--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -24,19 +24,10 @@ public extension String {
      Returns a localized representation of the string.
      
      - parameter bundle: Bundle were to search for localization.
-    */
-    public func localized(bundle: NSBundle = NSBundle.mainBundle()) -> String {
-        return NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: "")
-    }
-    
-    /**
-     Returns a localized representation of the string.
-     
-     - parameter bundle: Bundle were to search for localization.
      - parameter arguments: Formatting arguments.
      */
     public func localized(bundle: NSBundle = NSBundle.mainBundle(), arguments: CVarArgType...) -> String {
-        return String(format: localized(), arguments: arguments)
+        return String(format: NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: ""), arguments: arguments)
     }
     
     /**

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -22,6 +22,8 @@ public extension String {
     
     /**
      Returns a localized representation of the string.
+     
+     - parameter bundle: Bundle were to search for localization.
     */
     public func localized(bundle: NSBundle = NSBundle.mainBundle()) -> String {
         return NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: "")
@@ -30,6 +32,7 @@ public extension String {
     /**
      Returns a localized representation of the string.
      
+     - parameter bundle: Bundle were to search for localization.
      - parameter arguments: Formatting arguments.
      */
     public func localized(bundle: NSBundle = NSBundle.mainBundle(), arguments: CVarArgType...) -> String {

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -23,8 +23,8 @@ public extension String {
     /**
      Returns a localized representation of the string.
     */
-    public var localized: String {
-        return NSLocalizedString(self, tableName: nil, bundle: NSBundle.mainBundle(), value: "", comment: "")
+    public func localized(bundle: NSBundle = NSBundle.mainBundle()) -> String {
+        return NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: "")
     }
     
     /**
@@ -32,8 +32,8 @@ public extension String {
      
      - parameter arguments: Formatting arguments.
      */
-    public func localized(arguments: CVarArgType...) -> String {
-        return String(format: NSLocalizedString(self, tableName: nil, bundle: NSBundle.mainBundle(), value: "", comment: ""), arguments: arguments)
+    public func localized(bundle: NSBundle = NSBundle.mainBundle(), arguments: CVarArgType...) -> String {
+        return String(format: NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: ""), arguments: arguments)
     }
     
     /**

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -36,7 +36,7 @@ public extension String {
      - parameter arguments: Formatting arguments.
      */
     public func localized(bundle: NSBundle = NSBundle.mainBundle(), arguments: CVarArgType...) -> String {
-        return String(format: NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: ""), arguments: arguments)
+        return String(format: localized(), arguments: arguments)
     }
     
     /**

--- a/Core/Utilities/Alerts/ConfirmationAlertViewModel.swift
+++ b/Core/Utilities/Alerts/ConfirmationAlertViewModel.swift
@@ -36,9 +36,9 @@ public struct ConfirmationAlertViewModel {
     public init(
         title: String,
         message: String,
-        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized.localizedCapitalizedString,
+        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized().localizedCapitalizedString,
         dismissAction: ConfirmationAlertViewModel -> () = { _ in },
-        confirmButtonTitle: String = DefaultConfirmButtonTitleKey.localized.localizedCapitalizedString,
+        confirmButtonTitle: String = DefaultConfirmButtonTitleKey.localized().localizedCapitalizedString,
         confirmAction: ConfirmationAlertViewModel -> () = { _ in }) {
         self.title = title
         self.message = message

--- a/Core/Utilities/Alerts/ErrorAlertViewModel.swift
+++ b/Core/Utilities/Alerts/ErrorAlertViewModel.swift
@@ -29,7 +29,7 @@ public struct ErrorAlertViewModel {
     public init(
         title: String,
         message: String,
-        dismissButtonTitle: String = DefaultDismissButtonTitle.localized.localizedCapitalizedString,
+        dismissButtonTitle: String = DefaultDismissButtonTitle.localized().localizedCapitalizedString,
         dismissAction: ErrorAlertViewModel -> () = { _ in }) {
         self.title = title
         self.message = message


### PR DESCRIPTION
## Sumary ##

Making the `localized` String extension receive the bundle to use for localizing.

I found this useful when developing a framework with views, where I didn't want to localize with the main bundle (which is the framework user's one) but the framework's one.
