### PR TITLE
Fixes bug with localized strings with arguments.

### DIFF
--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -29,7 +29,11 @@ public extension String {
      - parameter arguments: Formatting arguments.
      */
     public func localized(withArguments arguments: CVarArg..., bundle: Bundle = Bundle.main) -> String {
-        return String(format: NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: ""), arguments: arguments)
+        let localized = NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: "")
+        if arguments.count > 0 {
+            return String(format: localized, arguments: arguments)
+        }
+        return localized
     }
     
     /**


### PR DESCRIPTION
## Summary ##

Fixes bug where localized strings with format but with no arguments passed would be incorrectly formatted.