### PR TITLE
Fixing NibLoadable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: objective-c
 osx_image: xcode8.2
 before_install:
 - sudo gem install bundler
+#For OS 10.2 all simulators are duplicated so we need to delete one
+# or a valid destination won't be found. (At least until travis fixes this)
+# Deleting an iPhone 6 simulator
+- xcrun simctl delete 1FD54EA7-5A25-4D6F-8599-D6F7687DA4EE
 script:
 - REPO_SLUG="$TRAVIS_REPO_SLUG" PULL_REQUEST="$TRAVIS_PULL_REQUEST" FORCE_CARTHAGE_VERSION=true
   script/cibuild

--- a/Core/Extensions/UIKit/UIView/NibLoadable.swift
+++ b/Core/Extensions/UIKit/UIView/NibLoadable.swift
@@ -13,20 +13,23 @@ import Foundation
  */
 public protocol NibLoadable: class {
     
-    static func loadFromNib(inBundle bundle: Bundle) -> Self?
+    // Using generics because using Self makes it impossible to
+    //   provide default implementations for non-final classes.
+    static func loadFromNib<T>(inBundle bundle: Bundle) -> T?
     
 }
 
-extension NibLoadable where Self: UIView {
+public extension NibLoadable where Self: UIView {
     
     /**
-        Loads the nib for the specific view , it will use the view name as the xib name.
+        Loads the nib for the specific view, it will use the view name as the xib name.
  
         - parameter bundle: Specific bundle, default = bundle for the class.
         - returns: The loaded UIView
     */
-    public static func loadFromNib(inBundle bundle: Bundle = Bundle(for: Self.self)) -> Self? {
+    public static func loadFromNib<T>(inBundle bundle: Bundle = Bundle(for: Self.self)) -> T? {
         let nibName = NSStringFromClass(self).components(separatedBy: ".").last
         return nibName.flatMap(bundle.loadNib)
     }
+    
 }


### PR DESCRIPTION
## Summary ##

Fixing NibLoadable protocol since in the current Swift, `Self` related functions can't be implemented by non-final classes.
And making extension public.