### PR TITLE
Adding RAC result extensions

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
-github "jdg/MBProgressHUD" "0.9.2"
+github "jdg/MBProgressHUD" "1.0.0"
 github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
+github "Quick/Quick" "v1.1.0"
 github "antitypical/Result" "3.1.0"
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-rc.2"
 github "ReactiveCocoa/ReactiveCocoa" "5.0.0-alpha.5"

--- a/Core.xcodeproj/project.pbxproj
+++ b/Core.xcodeproj/project.pbxproj
@@ -315,8 +315,8 @@
 		B95948331D4FDCD6003A082F /* ReactiveCocoa */ = {
 			isa = PBXGroup;
 			children = (
-				B95948341D4FDCD6003A082F /* SignalProducerSpec.swift */,
 				B95948351D4FDCD6003A082F /* SignalSpec.swift */,
+				B95948341D4FDCD6003A082F /* SignalProducerSpec.swift */,
 			);
 			name = ReactiveCocoa;
 			path = Extensions/ReactiveCocoa;

--- a/Core/Extensions/ReactiveCocoa/Signal.swift
+++ b/Core/Extensions/ReactiveCocoa/Signal.swift
@@ -7,18 +7,77 @@
 //
 
 import ReactiveSwift
+import Result
 
 public extension SignalProtocol {
     
     /**
-     Transforms a `Signal<Value, Error>` to `Signal<Value, NewError>`
-     This is usually useful when the `flatMap` operator is used and the outer
-     signal has `NoError` error type and the inner one a different type of error.
-     
-     - returns: A signal with the same value type but with `NewError` as the error type
+         Transforms a `Signal<Value, Error>` to `Signal<Value, NewError>`.
+         This is usually useful when the `flatMap` operator is used and the outer
+         signal has `NoError` error type and the inner one a different type of error.
+         
+         - returns: A signal with the same value type but with `NewError` as the error type
      */
     func liftError<NewError>() -> Signal<Value, NewError> {
         return flatMapError { _ in SignalProducer<Value, NewError>.empty }
+    }
+    
+    /**
+        Transforms the `Signal<Value, Error>` to `Signal<Result<Value, Error>, NoError>`.
+        This is usually useful when the `flatMap` triggers different signals
+        which if failed shouldn't finish the whole result signal, stopping new signals
+        from being triggered when a new value arrives at self.
+     
+        ```
+        var loginSignal: Signal<(), NoError>
+         
+        loginSignal.flatMap(.Latest) { _ -> Signal<MyUser, MyError> in
+            return authService.login()
+        }
+        ```
+     
+        It may be considered similar to the `events` signal of an `Action` (with only next and failed).
+    */
+    func toResultSignal() -> Signal<Result<Value, Error>, NoError> {
+        return map { Result<Value, Error>.success($0) }
+            .flatMapError { error -> SignalProducer<Result<Value, Error>, NoError> in
+                let errorValue = Result<Value, Error>.failure(error)
+                return SignalProducer<Result<Value, Error>, NoError>(value: errorValue)
+        }
+    }
+    
+}
+
+extension SignalProtocol where Value: ResultProtocol {
+    
+    /**
+        Transforms a `Signal<ResultProtocol<Value2, Error2>, Error>` to `Signal<Value2, Error>`,
+        ignoring all `Error2` events.
+     
+        It may be considered similar to the `values` signal of an `Action`.
+    */
+    func filterValues() -> Signal<Value.Value, Error> {
+        return filter {
+            if let _ = $0.value {
+                return true
+            }
+            return false
+        }.map { $0.value! }
+    }
+    
+    /**
+         Transforms a `Signal<ResultProtocol<Value2, Error2>, Error>` to `Signal<Error2, Error>`,
+         ignoring all `Value2` events.
+     
+         It may be considered similar to the `errors` signal of an `Action`.
+     */
+    func filterErrors() -> Signal<Value.Error, Error> {
+        return filter {
+            if let _ = $0.error {
+                return true
+            }
+            return false
+        }.map { $0.error! }
     }
     
 }

--- a/Core/Extensions/ReactiveCocoa/Signal.swift
+++ b/Core/Extensions/ReactiveCocoa/Signal.swift
@@ -48,7 +48,7 @@ public extension SignalProtocol {
     
 }
 
-extension SignalProtocol where Value: ResultProtocol {
+public extension SignalProtocol where Value: ResultProtocol {
     
     /**
         Transforms a `Signal<ResultProtocol<Value2, Error2>, Error>` to `Signal<Value2, Error>`,

--- a/Core/Extensions/ReactiveCocoa/SignalProducer.swift
+++ b/Core/Extensions/ReactiveCocoa/SignalProducer.swift
@@ -49,7 +49,7 @@ public extension SignalProducerProtocol {
     
 }
 
-extension SignalProducerProtocol where Value: ResultProtocol {
+public extension SignalProducerProtocol where Value: ResultProtocol {
     
     /**
          Transforms a `SignalProducer<ResultProtocol<Value2, Error2>, Error>`

--- a/Core/Extensions/ReactiveCocoa/SignalProducer.swift
+++ b/Core/Extensions/ReactiveCocoa/SignalProducer.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveSwift
+import Result
 
 public extension SignalProducerProtocol {
     
@@ -19,6 +20,67 @@ public extension SignalProducerProtocol {
      */
     func liftError<NewError>() -> SignalProducer<Value, NewError> {
         return flatMapError { _ in SignalProducer<Value, NewError>.empty }
+    }
+    
+    /**
+         Transforms the `SignalProducer<Value, Error>` to `SignalProducer<Result<Value, Error>, NoError>`.
+         This is usually useful when the `flatMap` triggers different producers
+         which if failed shouldn't finish the whole result producer, stopping new producers
+         from being triggered when a new value arrives at self.
+     
+         For example,
+         ```
+         var myProperty: MutableProperty<CLLocation>
+     
+         myProperty.producer.flatMap(.Latest) { clLocation -> SignalProducer<MyLocation, MyError> in
+             return locationService.fetchLocation(clLocation)
+         }
+         ```
+         
+         It may be considered similar to the `events` signal of an `Action` (with only next and failed).
+     */
+    func toResultSignalProducer() -> SignalProducer<Result<Value, Error>, NoError> {
+        return map { Result<Value, Error>.success($0) }
+            .flatMapError { error -> SignalProducer<Result<Value, Error>, NoError> in
+                let errorValue = Result<Value, Error>.failure(error)
+                return SignalProducer<Result<Value, Error>, NoError>(value: errorValue)
+        }
+    }
+    
+}
+
+extension SignalProducerProtocol where Value: ResultProtocol {
+    
+    /**
+         Transforms a `SignalProducer<ResultProtocol<Value2, Error2>, Error>`
+         to `SignalProducer<Value2, Error>`, ignoring all `Error2` events.
+         
+         It may be considered similar to the `values` signal of an `Action`,
+         but for producers.
+     */
+    func filterValues() -> SignalProducer<Value.Value, Error> {
+        return filter {
+            if let _ = $0.value {
+                return true
+            }
+            return false
+        }.map { $0.value! }
+    }
+    
+    /**
+         Transforms a `SignalProducer<ResultProtocol<Value2, Error2>, Error>`
+         to `SignalProducer<Error2, Error>`, ignoring all `Value2` events.
+         
+         It may be considered similar to the `errors` signal of an `Action`,
+         but for producers.
+     */
+    func filterErrors() -> SignalProducer<Value.Error, Error> {
+        return filter {
+            if let _ = $0.error {
+                return true
+            }
+            return false
+        }.map { $0.error! }
     }
     
 }

--- a/Core/Utilities/ProgressHUD/ProgressHUDDelegate.swift
+++ b/Core/Utilities/ProgressHUD/ProgressHUDDelegate.swift
@@ -39,7 +39,7 @@ extension UIViewController: ProgressHUDDelegate {
         let progressHUD: MBProgressHUD = MBProgressHUD.showAdded(to: view, animated: true)
         
         if let labelText = text {
-            progressHUD.labelText = labelText
+            progressHUD.label.text = labelText
         }
     }
     

--- a/CoreTests/Extensions/ReactiveCocoa/SignalProducerSpec.swift
+++ b/CoreTests/Extensions/ReactiveCocoa/SignalProducerSpec.swift
@@ -39,20 +39,18 @@ public class SignalProducerSpec: QuickSpec {
                     
                     converted.collect().startWithValues {
                         expect($0).to(beEmpty())
+                        done()
                     }
                     property.value = ""
                 }}
                 
                 it("should not ignore a value") { waitUntil { done in
-                    
                     let converted: SignalProducer<(), NoError> = producer.liftError()
                     
-                    converted.collect().startWithValues {
-                        expect($0.count).to(equal(2))
+                    converted.startWithValues {
                         done()
                     }
                     property.value = "value"
-                    property.value = ""
                 }}
                 
             }
@@ -120,7 +118,7 @@ public class SignalProducerSpec: QuickSpec {
                         observer.send(value: .success())
                         observer.sendCompleted()
                     }
-                    let converted = producer.toResultSignalProducer()
+                    let converted = producer.filterValues()
                     converted.collect().startWithValues {
                         expect($0.count).to(equal(1))
                         done()
@@ -136,7 +134,7 @@ public class SignalProducerSpec: QuickSpec {
                         observer.send(value: .failure(NSError(domain: "", code: 0, userInfo: [:])))
                         observer.sendCompleted()
                     }
-                    let converted = producer.toResultSignalProducer()
+                    let converted = producer.filterValues()
                     converted.collect().startWithValues {
                         expect($0.count).to(equal(0))
                         done()
@@ -156,7 +154,7 @@ public class SignalProducerSpec: QuickSpec {
                         observer.send(value: .success())
                         observer.sendCompleted()
                     }
-                    let converted = producer.toResultSignalProducer()
+                    let converted = producer.filterErrors()
                     converted.collect().startWithValues {
                         expect($0.count).to(equal(0))
                         done()
@@ -172,7 +170,7 @@ public class SignalProducerSpec: QuickSpec {
                         observer.send(value: .failure(NSError(domain: "", code: 0, userInfo: [:])))
                         observer.sendCompleted()
                     }
-                    let converted = producer.toResultSignalProducer()
+                    let converted = producer.filterErrors()
                     converted.collect().startWithValues {
                         expect($0.count).to(equal(1))
                         done()

--- a/CoreTests/Extensions/ReactiveCocoa/SignalSpec.swift
+++ b/CoreTests/Extensions/ReactiveCocoa/SignalSpec.swift
@@ -8,7 +8,7 @@
 
 import Quick
 import Nimble
-import enum Result.NoError
+import Result
 import ReactiveSwift
 import Core
 
@@ -21,27 +21,174 @@ public class SignalSpec: QuickSpec {
             context("When lifting an error") {
 
                 var signal: Signal<(), NSError>!
-                
                 var observer: Observer<(), NSError>!
+                var converted: Signal<(), NoError>!
                 
                 beforeEach {
                     let (_signal, _observer) = Signal<(), NSError>.pipe()
                     signal = _signal
                     observer = _observer
+                    converted = signal.liftError()
                 }
                 
-                it("should ignore the error and complete") {
-                    
-                    let converted: Signal<(), NoError> = signal.liftError()
-                    
+                it("should ignore the error and complete") { waitUntil { done in
                     converted.collect().observeValues {
                         expect($0).to(beEmpty())
+                        done()
                     }
-                    
                     observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
-                }
+                }}
+                
+                it("should not ignore a value") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(2))
+                        done()
+                    }
+                    observer.send(value: ())
+                    observer.send(value: ())
+                    observer.sendCompleted()
+                }}
+                
             }
             
         }
+        
+        describe("#toResultSignal") {
+            
+            var signal: Signal<(), NSError>!
+            var observer: Observer<(), NSError>!
+            var converted: Signal<Result<(), NSError>, NoError>!
+            
+            beforeEach {
+                let (_signal, _observer) = Signal<(), NSError>.pipe()
+                signal = _signal
+                observer = _observer
+                converted = signal.toResultSignal()
+            }
+            
+            context("When sending a value") {
+                
+                it("should send on the value wrapped") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(1))
+                        done()
+                    }
+                    observer.send(value: ())
+                    observer.sendCompleted()
+                }}
+                
+            }
+            
+            context("When sending an error") {
+                
+                it("should send on the error as a wrapped value") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(1))
+                        done()
+                    }
+                    observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                }}
+                
+            }
+            
+            context("When sending values and errors") {
+                
+                it("should send on everything wrapped up until it completes") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(2))
+                        done()
+                    }
+                    observer.send(value: ())
+                    observer.send(error: NSError(domain: "", code: 0, userInfo: [:]))
+                    observer.send(value: ())
+                }}
+                
+            }
+            
+        }
+        
+        describe("#filterValues") {
+            
+            var signal: Signal<Result<(), NSError>, NoError>!
+            var observer: Observer<Result<(), NSError>, NoError>!
+            var converted: Signal<(), NoError>!
+            
+            beforeEach {
+                let (_signal, _observer) = Signal<Result<(), NSError>, NoError>.pipe()
+                signal = _signal
+                observer = _observer
+                converted = signal.filterValues()
+            }
+            
+            context("When sending a success value") {
+                
+                it("should send on the value") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(1))
+                        done()
+                    }
+                    observer.send(value: .success())
+                    observer.sendCompleted()
+                }}
+                
+            }
+            
+            context("When sending a failure value") {
+                
+                it("shouldn't send on the error") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(0))
+                        done()
+                    }
+                    observer.send(value: .failure(NSError(domain: "", code: 0, userInfo: [:])))
+                    observer.sendCompleted()
+                }}
+            
+            }
+        
+        }
+        
+        describe("#filterErrors") {
+            
+            var signal: Signal<Result<(), NSError>, NoError>!
+            var observer: Observer<Result<(), NSError>, NoError>!
+            var converted: Signal<NSError, NoError>!
+            
+            beforeEach {
+                let (_signal, _observer) = Signal<Result<(), NSError>, NoError>.pipe()
+                signal = _signal
+                observer = _observer
+                converted = signal.filterErrors()
+            }
+            
+            context("When sending a success value") {
+                
+                it("shouldn't send on the value") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(0))
+                        done()
+                    }
+                    observer.send(value: .success())
+                    observer.sendCompleted()
+                }}
+                
+            }
+            
+            context("When sending a failure value") {
+                
+                it("should send on the error") { waitUntil { done in
+                    converted.collect().observeValues {
+                        expect($0.count).to(equal(1))
+                        done()
+                    }
+                    observer.send(value: .failure(NSError(domain: "", code: 0, userInfo: [:])))
+                    observer.sendCompleted()
+                }}
+                
+            }
+            
+        }
+        
     }
+    
 }


### PR DESCRIPTION
## Summary ##

Adding RAC result extensions needed in Wolmo-Auth.
They transform the value to a result value for values and errors and filtering.
