### PR TITLE
Adding dequeue cell functions to table view and collection view

### DIFF
--- a/Core.xcodeproj/project.pbxproj
+++ b/Core.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		CE3A9BA11E607B28005D7E8F /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B8C1E607B28005D7E8F /* UIView.swift */; };
 		CE3A9BA21E607B28005D7E8F /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B8D1E607B28005D7E8F /* UIViewController.swift */; };
 		CE80E0F11E82D1F9005C300E /* PathAppendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80E0F01E82D1F9005C300E /* PathAppendable.swift */; };
+		CED934851E8456480017CF96 /* UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED934841E8456480017CF96 /* UICollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -156,6 +157,7 @@
 		CE3A9B8C1E607B28005D7E8F /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		CE3A9B8D1E607B28005D7E8F /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		CE80E0F01E82D1F9005C300E /* PathAppendable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathAppendable.swift; sourceTree = "<group>"; };
+		CED934841E8456480017CF96 /* UICollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -395,6 +397,7 @@
 			children = (
 				CE3A9B841E607B28005D7E8F /* UIAlertController.swift */,
 				CE3A9B851E607B28005D7E8F /* UIButton.swift */,
+				CED934841E8456480017CF96 /* UICollectionView.swift */,
 				CE3A9B861E607B28005D7E8F /* UIColor.swift */,
 				CE3A9B871E607B28005D7E8F /* UITableView.swift */,
 				CE3A9B881E607B28005D7E8F /* UITextField.swift */,
@@ -585,6 +588,7 @@
 				CE3A9B951E607B28005D7E8F /* NSURL.swift in Sources */,
 				CE3A9B971E607B28005D7E8F /* String.swift in Sources */,
 				CE3A9B911E607B28005D7E8F /* Date.swift in Sources */,
+				CED934851E8456480017CF96 /* UICollectionView.swift in Sources */,
 				B988B9811D24621000824685 /* DeviceType.swift in Sources */,
 				B988B97E1D244D6300824685 /* ErrorAlertViewModel.swift in Sources */,
 				CE3A9BA11E607B28005D7E8F /* UIView.swift in Sources */,

--- a/Core/Extensions/UIKit/UICollectionView.swift
+++ b/Core/Extensions/UIKit/UICollectionView.swift
@@ -1,0 +1,34 @@
+//
+//  UICollectionView.swift
+//  Core
+//
+//  Created by Daniela Riesgo on 3/23/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import UIKit
+
+public extension UICollectionView {
+    
+    /**
+         Registers a cell to be used by a UICollectionView.
+         
+         - parameter cellType: An identifiable cell to take the identifier from.
+     */
+    func register(cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
+        register(UINib(nibName: cellType.cellIdentifier, bundle: bundle), forCellWithReuseIdentifier: cellType.cellIdentifier)
+    }
+    
+    /**
+         Returns a reusable cell of the type specified to be used and adds it
+         to the UICollectionView in the indexPath specified.
+         
+         - parameter cellType: An identifiable cell to take the identifier from.
+         - parameter indexPath: IndexPath where to add the cell to the collection view.
+     */
+    func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
+        //swiftlint:disable:next force_cast
+        return dequeueReusableCell(withReuseIdentifier: cellType.cellIdentifier, for: indexPath) as! T
+    }
+    
+}

--- a/Core/Extensions/UIKit/UICollectionView.swift
+++ b/Core/Extensions/UIKit/UICollectionView.swift
@@ -14,8 +14,9 @@ public extension UICollectionView {
          Registers a cell to be used by a UICollectionView.
          
          - parameter cellType: An identifiable cell to take the identifier from.
+         - parameter bundle: The Bundle where the Nib for the cell is located.
      */
-    func register(cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
+    public func register(_ cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
         register(UINib(nibName: cellType.cellIdentifier, bundle: bundle), forCellWithReuseIdentifier: cellType.cellIdentifier)
     }
     
@@ -26,7 +27,7 @@ public extension UICollectionView {
          - parameter cellType: An identifiable cell to take the identifier from.
          - parameter indexPath: IndexPath where to add the cell to the collection view.
      */
-    func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
+    public func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
         //swiftlint:disable:next force_cast
         return dequeueReusableCell(withReuseIdentifier: cellType.cellIdentifier, for: indexPath) as! T
     }

--- a/Core/Extensions/UIKit/UITableView.swift
+++ b/Core/Extensions/UIKit/UITableView.swift
@@ -11,12 +11,35 @@ import UIKit
 public extension UITableView {
     
     /**
-     Registers a cell to be used by a UITableView.
-     
-     - parameter cellType: An identifiable cell to take the identifier from.
+         Registers a cell to be used by a UITableView.
+         
+         - parameter cellType: An identifiable cell to take the identifier from.
+         - parameter bundle: The Bundle where the Nib for the cell is located.
      */
-    func register(cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
+    func register(_ cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
         register(UINib(nibName: cellType.cellIdentifier, bundle: bundle), forCellReuseIdentifier: cellType.cellIdentifier)
+    }
+    
+    /**
+         Returns a reusable cell of the type specified to be used by a UITableView.
+         
+         - parameter cellType: An identifiable cell to take the identifier from.
+     */
+    func dequeue<T: IdentifiableCell>(_ cellType: T.Type) -> T {
+        //swiftlint:disable:next force_cast
+        return dequeueReusableCell(withIdentifier: cellType.cellIdentifier) as! T
+    }
+    
+    /**
+         Returns a reusable cell of the type specified to be used and adds it
+          to the UITableView in the indexPath specified.
+         
+         - parameter cellType: An identifiable cell to take the identifier from.
+         - parameter indexPath: IndexPath where to add the cell to the table view.
+     */
+    func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
+        //swiftlint:disable:next force_cast
+        return dequeueReusableCell(withIdentifier: cellType.cellIdentifier, for: indexPath) as! T
     }
     
 }

--- a/Core/Extensions/UIKit/UITableView.swift
+++ b/Core/Extensions/UIKit/UITableView.swift
@@ -16,7 +16,7 @@ public extension UITableView {
          - parameter cellType: An identifiable cell to take the identifier from.
          - parameter bundle: The Bundle where the Nib for the cell is located.
      */
-    func register(_ cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
+    public func register(_ cellType: IdentifiableCell.Type, bundle: Bundle? = .none) {
         register(UINib(nibName: cellType.cellIdentifier, bundle: bundle), forCellReuseIdentifier: cellType.cellIdentifier)
     }
     
@@ -25,7 +25,7 @@ public extension UITableView {
          
          - parameter cellType: An identifiable cell to take the identifier from.
      */
-    func dequeue<T: IdentifiableCell>(_ cellType: T.Type) -> T {
+    public func dequeue<T: IdentifiableCell>(_ cellType: T.Type) -> T {
         //swiftlint:disable:next force_cast
         return dequeueReusableCell(withIdentifier: cellType.cellIdentifier) as! T
     }
@@ -37,7 +37,7 @@ public extension UITableView {
          - parameter cellType: An identifiable cell to take the identifier from.
          - parameter indexPath: IndexPath where to add the cell to the table view.
      */
-    func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
+    public func dequeue<T: IdentifiableCell>(_ cellType: T.Type, for indexPath: IndexPath) -> T {
         //swiftlint:disable:next force_cast
         return dequeueReusableCell(withIdentifier: cellType.cellIdentifier, for: indexPath) as! T
     }


### PR DESCRIPTION
## Summary ##
Adding dequeue cell functions for UITableView.
Adding all cell functions that UITableView has to UICollectionView.

## Known issues ##
Can't add tests since it requires to load a Nib.