### PR TITLE
Removing  and letting user decide in alert actions texts.

### DIFF
--- a/Core/Utilities/Alerts/ConfirmationAlertViewModel.swift
+++ b/Core/Utilities/Alerts/ConfirmationAlertViewModel.swift
@@ -36,9 +36,9 @@ public struct ConfirmationAlertViewModel {
     public init(
         title: String,
         message: String,
-        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized().localizedCapitalized,
+        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized(),
         dismissAction: @escaping (ConfirmationAlertViewModel) -> Void = { _ in },
-        confirmButtonTitle: String = DefaultConfirmButtonTitleKey.localized().localizedCapitalized,
+        confirmButtonTitle: String = DefaultConfirmButtonTitleKey.localized(),
         confirmAction: @escaping (ConfirmationAlertViewModel) -> Void = { _ in }) {
         self.title = title
         self.message = message

--- a/Core/Utilities/Alerts/ErrorAlertViewModel.swift
+++ b/Core/Utilities/Alerts/ErrorAlertViewModel.swift
@@ -29,7 +29,7 @@ public struct ErrorAlertViewModel {
     public init(
         title: String,
         message: String,
-        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized().localizedCapitalized,
+        dismissButtonTitle: String = DefaultDismissButtonTitleKey.localized(),
         dismissAction: @escaping (ErrorAlertViewModel) -> Void = { _ in }) {
         self.title = title
         self.message = message

--- a/CoreTests/Utilities/Alerts/ConfirmationAlertViewModelSpec.swift
+++ b/CoreTests/Utilities/Alerts/ConfirmationAlertViewModelSpec.swift
@@ -59,7 +59,7 @@ public class ConfirmationAlertViewModelSpec: QuickSpec {
             context("When using the default parameter") {
 
                 it("should match the localized value of #DefaultDismissButtonTitleKey") {
-                    let defaultTitle = ConfirmationAlertViewModel.DefaultDismissButtonTitleKey.localized().localizedCapitalized
+                    let defaultTitle = ConfirmationAlertViewModel.DefaultDismissButtonTitleKey.localized()
                     let title = defaultConfirmationAlertViewModel.dismissButtonTitle
                     expect(defaultTitle).to(equal(title))
                 }
@@ -79,7 +79,7 @@ public class ConfirmationAlertViewModelSpec: QuickSpec {
             context("When using the default parameter") {
                 
                 it("should match the localized value of #DefaultConfirmButtonTitleKey") {
-                    let defaultTitle = ConfirmationAlertViewModel.DefaultConfirmButtonTitleKey.localized().localizedCapitalized
+                    let defaultTitle = ConfirmationAlertViewModel.DefaultConfirmButtonTitleKey.localized()
                     let title = defaultConfirmationAlertViewModel.confirmButtonTitle
                     expect(defaultTitle).to(equal(title))
                 }

--- a/CoreTests/Utilities/Alerts/ErrorAlertViewModelSpec.swift
+++ b/CoreTests/Utilities/Alerts/ErrorAlertViewModelSpec.swift
@@ -56,7 +56,7 @@ public class ErrorAlertViewModelSpec: QuickSpec {
             context("When using the default parameter") {
                 
                 it("should match the localized value of #DefaultDismissButtonTitleKey") {
-                    let defaultTitle = ErrorAlertViewModel.DefaultDismissButtonTitleKey.localized().localizedCapitalized
+                    let defaultTitle = ErrorAlertViewModel.DefaultDismissButtonTitleKey.localized()
                     let title = defaultErrorAlertViewModel.dismissButtonTitle
                     expect(defaultTitle).to(equal(title))
                 }


### PR DESCRIPTION
## Summary ##
**Issue**: #53 

Removing `localizedCapitalized` from alerts to let the user decide in the strings file exactly how he wants it to appear on screen.