### PR TITLE
Format attributes

### DIFF
--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -48,7 +48,7 @@ public extension String {
      
      - seealso: NSMutableAttributedString.addAttributes(_:range:)
     */
-    public func format(attributes attrs: [String: [String : Any]]) -> NSAttributedString {
+    public func format(withAttributes attrs: [String: [String : Any]]) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
         let nSStringWithFormat = self as NSString
         for (substring, attributes) in attrs {

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -48,7 +48,7 @@ public extension String {
      
      - seealso: NSMutableAttributedString.addAttributes(_:range:)
     */
-    public func format(withAttributes attrs: [String: [String : Any]]) -> NSAttributedString {
+    public func format(withAttributes attrs: [String: [String: Any]]) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
         let nSStringWithFormat = self as NSString
         for (substring, attributes) in attrs {

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -36,7 +36,27 @@ public extension String {
     public func format(with arguments: CVarArg...) -> String {
         return String(format: self, arguments: arguments)
     }
-    
+
+    /**
+     Returns an NSAttributedString with the same content as self but
+     with the attributes specified for each first appearance of substrings passed.
+     
+     - parameter attributes: A dictionary that specifies the attributes to add to the
+        substring specified. The attributes should be specified with a dictionary itself
+        in the same format required by the NSAttributedString. The possible keys are
+        specified in `NSAttributedString.h` (like `NSFontAttributeName`).
+     
+     - seealso: NSMutableAttributedString.addAttributes(_:range:)
+    */
+    public func format(attributes attrs: [String: [String : Any]]) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: self)
+        let nSStringWithFormat = self as NSString
+        for (substring, attributes) in attrs {
+            attributedString.addAttributes(attributes, range: nSStringWithFormat.range(of: substring))
+        }
+        return attributedString
+    }
+
     /**
      Returns the length of the string.
      

--- a/CoreTests/Extensions/Foundation/StringSpec.swift
+++ b/CoreTests/Extensions/Foundation/StringSpec.swift
@@ -24,6 +24,46 @@ public class StringSpec: QuickSpec {
             }
             
         }
+
+        describe("#format(withAttributes:)") {
+
+            it("should add the attributes to the string when the substring exists") {
+                let string = "Come and check our interesting posts at Wolox."
+                let attrs = ["Come and check our interesting posts at Wolox.":
+                                [NSFontAttributeName: "Helvetica-Regular"],
+                             "Wolox":
+                                [NSLinkAttributeName: URL(string: "www.wolox.com.ar")!,
+                                 NSForegroundColorAttributeName: UIColor.blue],
+                             "posts":
+                                [NSForegroundColorAttributeName: UIColor.red],
+                             "and some more":
+                                [NSForegroundColorAttributeName: UIColor.green]]
+                let attrString = string.format(withAttributes: attrs)
+                attrString.enumerateAttributes(in: NSRange(location: 0, length: attrString.length),
+                                               using: { (attributes, range, _) in
+                    let nsString = string as NSString
+                    if nsString.substring(with: range) == "Come and check our interesting " ||
+                       nsString.substring(with: range) == " at " ||
+                       nsString.substring(with: range) == "." {
+                        expect(attributes.count).to(equal(1))
+                        expect(attributes[NSFontAttributeName] as? String).to(equal("Helvetica-Regular"))
+                    } else if nsString.substring(with: range) == "Wolox" {
+                        expect(attributes.count).to(equal(3))
+                        expect(attributes[NSFontAttributeName] as? String).to(equal("Helvetica-Regular"))
+                        expect(attributes[NSLinkAttributeName] as? URL).to(equal(URL(string: "www.wolox.com.ar")))
+                        expect(attributes[NSForegroundColorAttributeName] as? UIColor).to(equal(UIColor.blue))
+                    } else if nsString.substring(with: range) == "posts" {
+                        expect(attributes.count).to(equal(2))
+                        expect(attributes[NSFontAttributeName] as? String).to(equal("Helvetica-Regular"))
+                        expect(attributes[NSForegroundColorAttributeName] as? UIColor).to(equal(UIColor.red))
+                    } else {
+                        fail()
+                    }
+                })
+
+            }
+
+        }
         
         describe("#length") {
             


### PR DESCRIPTION
## Summary ##

Adding attributes formatting function.

Taken from [Istali](https://github.com/Wolox/istali-iOS/pull/24/files#diff-7930999c529c2ecb56955f2c1d95566fR13).

What do you think of making the `attrs` property a `[String?: [String : Any]]` and so if it is .none it means the entire text, or leave it as it was and make the empty string mean all the text? Do you think it is a useful shortcut? or it wouldn't be useful because the programmer most probably has the entire text in a variable and can easily pass it?