### PR TITLE
Adding default value functions to Dictionary

### DIFF
--- a/Core/Extensions/Foundation/Dictionary.swift
+++ b/Core/Extensions/Foundation/Dictionary.swift
@@ -52,9 +52,15 @@ public extension Dictionary where Value == Any {
          if the key didn't have a value or if it couldn't be casted to T.
 
          Uses autoclosure so your default value won't be created if it's not needed.
+     
+         - warning: This will raise a runtime error if there is a value in the dictionary
+                but it's not of the same time as the default value. For that case, you should
+                handle it some other way.
      */
     public func castedValue<T>(forKey key: Key, or defaultValue: @autoclosure () -> T) -> T {
-       return self[key] as? T ?? defaultValue()
+        guard let value = self[key] else { return defaultValue() }
+        //swiftlint:disable:next force_cast
+        return value as! T
     }
 
 }

--- a/Core/Extensions/Foundation/Dictionary.swift
+++ b/Core/Extensions/Foundation/Dictionary.swift
@@ -31,5 +31,30 @@ public extension Dictionary {
             updateValue(value, forKey: key)
         }
     }
-    
+
+    /**
+         Returns the value associated with the specified key,
+         or the specified default value if the key didn't have a value.
+     
+         Uses autoclosure so your default value won't be created if it's not needed.
+     */
+    public func value(forKey key: Key, or defaultValue: @autoclosure () -> Value) -> Value {
+        return self[key] ?? defaultValue()
+    }
+
+}
+
+public extension Dictionary where Value == Any {
+
+    /**
+         Returns the value associated with the specified key casted to T
+         (the type of the default value), or the specified default value
+         if the key didn't have a value or if it couldn't be casted to T.
+
+         Uses autoclosure so your default value won't be created if it's not needed.
+     */
+    public func castedValue<T>(forKey key: Key, or defaultValue: @autoclosure () -> T) -> T {
+       return self[key] as? T ?? defaultValue()
+    }
+
 }

--- a/Core/Extensions/Foundation/Dictionary.swift
+++ b/Core/Extensions/Foundation/Dictionary.swift
@@ -53,14 +53,16 @@ public extension Dictionary where Value == Any {
 
          Uses autoclosure so your default value won't be created if it's not needed.
      
-         - warning: This will raise a runtime error if there is a value in the dictionary
+         - warning: This will raise a runtime assertion error if there is a value in the dictionary
                 but it's not of the same time as the default value. For that case, you should
                 handle it some other way.
      */
     public func castedValue<T>(forKey key: Key, or defaultValue: @autoclosure () -> T) -> T {
         guard let value = self[key] else { return defaultValue() }
-        //swiftlint:disable:next force_cast
-        return value as! T
+        guard let castedValue = value as? T else {
+            fatalError("The dictionary's value to key \(key) is not of type \(T.self)")
+        }
+        return castedValue
     }
 
 }

--- a/CoreTests/Extensions/Foundation/DictionarySpec.swift
+++ b/CoreTests/Extensions/Foundation/DictionarySpec.swift
@@ -150,11 +150,9 @@ public class DictionarySpec: QuickSpec {
 
                 context("when the key's value's type is not T") {
 
-                    // Not being able to catch error with Nimble.
-                    // Tried with throwError, raiseException or throwAssertion.
-//                    it("should raise a runtime error") {
-//                        expect(_ = dict1.castedValue(forKey: 2, or: "two")).to(throwError())
-//                    }
+                    it("should raise a runtime error") {
+                        expect(_ = dict1.castedValue(forKey: 2, or: "two")).to(throwAssertion())
+                    }
 
                 }
 

--- a/CoreTests/Extensions/Foundation/DictionarySpec.swift
+++ b/CoreTests/Extensions/Foundation/DictionarySpec.swift
@@ -109,6 +109,75 @@ public class DictionarySpec: QuickSpec {
             }
             
         }
+
+        describe("value(forKey:or:)") {
+
+            var dict1: [Int: String]!
+
+            beforeEach {
+                dict1 = [1: "one", 2: "two", 3: "three"]
+            }
+
+            context("when the key is already in the dictionary") {
+
+                it("should return the key's value") {
+                    let value = dict1.value(forKey: 2, or: "dos")
+                    expect(value).to(equal("two"))
+                }
+
+            }
+
+            context("when the key is not in the dictionary") {
+
+                it("should return the default value") {
+                    let value = dict1.value(forKey: 4, or: "cuatro")
+                    expect(value).to(equal("cuatro"))
+                }
+                
+            }
+
+        }
+
+        describe("castedValue(forKey:or:)") {
+
+            var dict1: [Int: Any]!
+
+            beforeEach {
+                dict1 = [1: "one", 2: 2, 3: [",", ".", ":"]]
+            }
+
+            context("when the key is already in the dictionary") {
+
+                context("when the key's value's type is not T") {
+
+                    it("should return the default value") {
+                        let value = dict1.castedValue(forKey: 2, or: "two")
+                        expect(value).to(equal("two"))
+                    }
+
+                }
+
+                context("when the key's value's type is T") {
+
+                    it("should return the key's value") {
+                        let value = dict1.castedValue(forKey: 1, or: "uno")
+                        expect(value).to(equal("one"))
+                    }
+
+                }
+
+            }
+
+            context("when the key is not in the dictionary") {
+                
+                it("should return the default value") {
+                    let value = dict1.castedValue(forKey: 5, or: ["español": "cinco"])
+                    expect(value).to(equal(["español": "cinco"]))
+                }
+                
+            }
+
+        }
         
     }
 

--- a/CoreTests/Extensions/Foundation/DictionarySpec.swift
+++ b/CoreTests/Extensions/Foundation/DictionarySpec.swift
@@ -150,10 +150,11 @@ public class DictionarySpec: QuickSpec {
 
                 context("when the key's value's type is not T") {
 
-                    it("should return the default value") {
-                        let value = dict1.castedValue(forKey: 2, or: "two")
-                        expect(value).to(equal("two"))
-                    }
+                    // Not being able to catch error with Nimble.
+                    // Tried with throwError, raiseException or throwAssertion.
+//                    it("should raise a runtime error") {
+//                        expect(_ = dict1.castedValue(forKey: 2, or: "two")).to(throwError())
+//                    }
 
                 }
 


### PR DESCRIPTION
## Summary ##

Adding a get to dictionaries where you can provide a default value.
Taken from [this](https://www.swiftbysundell.com/posts/using-autoclosure-when-designing-swift-apis?utm_campaign=This%2BWeek%2Bin%2BSwift&utm_medium=email&utm_source=This_Week_in_Swift_133) post.

## Known issues

For dictionaries whose Value is exactly Any (== Any, not : Any), it seems useful to be able to cast it directly (as the post proposes), but we can't do it with the same name as the function for all dictionaries because they collide and finally apple interprets it as the Value function and ignores the generic function.
I couldn't think of a better thing to do than changing the name for them not to collide, because I couldn't find a way to create for example an extension for all dictionaries whose value is not Any.
