### PR TITLE
Textfield's fontTextStyle property

### DIFF
--- a/Core.xcodeproj/project.pbxproj
+++ b/Core.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		CEE9BFCB1E8986DC00D0E65D /* IdentifiableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9BFC61E8986DC00D0E65D /* IdentifiableSpec.swift */; };
 		CEE9BFCC1E8986DC00D0E65D /* PathAppendableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9BFC71E8986DC00D0E65D /* PathAppendableSpec.swift */; };
 		CEE9BFCE1E8986F700D0E65D /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9BFCD1E8986F700D0E65D /* Collection.swift */; };
+		CEEC517E1EE5ECD300BC41FE /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC517D1EE5ECD300BC41FE /* UILabel.swift */; };
+		CEEC51801EE5EE3400BC41FE /* UILabelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC517F1EE5EE3400BC41FE /* UILabelSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +195,8 @@
 		CEE9BFC61E8986DC00D0E65D /* IdentifiableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifiableSpec.swift; sourceTree = "<group>"; };
 		CEE9BFC71E8986DC00D0E65D /* PathAppendableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathAppendableSpec.swift; sourceTree = "<group>"; };
 		CEE9BFCD1E8986F700D0E65D /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		CEEC517D1EE5ECD300BC41FE /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
+		CEEC517F1EE5EE3400BC41FE /* UILabelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -382,6 +386,7 @@
 				CE3A9B851E607B28005D7E8F /* UIButton.swift */,
 				CED934841E8456480017CF96 /* UICollectionView.swift */,
 				CE3A9B861E607B28005D7E8F /* UIColor.swift */,
+				CEEC517D1EE5ECD300BC41FE /* UILabel.swift */,
 				CE3A9B871E607B28005D7E8F /* UITableView.swift */,
 				CE3A9B881E607B28005D7E8F /* UITextField.swift */,
 				CE3A9B891E607B28005D7E8F /* UIView */,
@@ -442,6 +447,7 @@
 				CEE9BFB21E8986D400D0E65D /* UIColorSpec.swift */,
 				CE11868A1EA7A0CD00105D6F /* UITableViewSpec.swift */,
 				CEE9BFB31E8986D400D0E65D /* UITextFieldSpec.swift */,
+				CEEC517F1EE5EE3400BC41FE /* UILabelSpec.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -606,6 +612,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEEC517E1EE5ECD300BC41FE /* UILabel.swift in Sources */,
 				CE80E0F11E82D1F9005C300E /* PathAppendable.swift in Sources */,
 				CE3A9BA21E607B28005D7E8F /* UIViewController.swift in Sources */,
 				B9F63CC21D5CE7FA00D09C1D /* Identifiable.swift in Sources */,
@@ -657,6 +664,7 @@
 				CEE9BFCC1E8986DC00D0E65D /* PathAppendableSpec.swift in Sources */,
 				CE1186941EA7A7C600105D6F /* GeneralSpec.swift in Sources */,
 				CEE9BFB91E8986D400D0E65D /* StringSpec.swift in Sources */,
+				CEEC51801EE5EE3400BC41FE /* UILabelSpec.swift in Sources */,
 				CEE9BFCA1E8986DC00D0E65D /* AssociatedObjectSpec.swift in Sources */,
 				CEE9BFBF1E8986D400D0E65D /* UIColorSpec.swift in Sources */,
 				CE1186AC1EA7F67800105D6F /* BundleSpec.swift in Sources */,

--- a/Core.xcodeproj/project.pbxproj
+++ b/Core.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		CE1186A61EA7E2A200105D6F /* NibLoadableUICollectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1186A51EA7E2A200105D6F /* NibLoadableUICollectionView.xib */; };
 		CE1186A81EA7EF2E00105D6F /* NibLoadableUITableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1186A71EA7EF2E00105D6F /* NibLoadableUITableView.xib */; };
 		CE1186AC1EA7F67800105D6F /* BundleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1186AB1EA7F67800105D6F /* BundleSpec.swift */; };
+		CE228AE01EF2FE1E00097B19 /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE228ADF1EF2FE1E00097B19 /* UIFont.swift */; };
 		CE3A9B8E1E607B28005D7E8F /* AVAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B751E607B28005D7E8F /* AVAsset.swift */; };
 		CE3A9B8F1E607B28005D7E8F /* AVPlayerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B761E607B28005D7E8F /* AVPlayerItem.swift */; };
 		CE3A9B901E607B28005D7E8F /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B781E607B28005D7E8F /* Array.swift */; };
@@ -154,6 +155,7 @@
 		CE1186A51EA7E2A200105D6F /* NibLoadableUICollectionView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibLoadableUICollectionView.xib; sourceTree = "<group>"; };
 		CE1186A71EA7EF2E00105D6F /* NibLoadableUITableView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibLoadableUITableView.xib; sourceTree = "<group>"; };
 		CE1186AB1EA7F67800105D6F /* BundleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleSpec.swift; sourceTree = "<group>"; };
+		CE228ADF1EF2FE1E00097B19 /* UIFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		CE3A9B751E607B28005D7E8F /* AVAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVAsset.swift; sourceTree = "<group>"; };
 		CE3A9B761E607B28005D7E8F /* AVPlayerItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVPlayerItem.swift; sourceTree = "<group>"; };
 		CE3A9B781E607B28005D7E8F /* Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				CE3A9B881E607B28005D7E8F /* UITextField.swift */,
 				CE3A9B891E607B28005D7E8F /* UIView */,
 				CE3A9B8D1E607B28005D7E8F /* UIViewController.swift */,
+				CE228ADF1EF2FE1E00097B19 /* UIFont.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				CEEC517E1EE5ECD300BC41FE /* UILabel.swift in Sources */,
 				CE80E0F11E82D1F9005C300E /* PathAppendable.swift in Sources */,
 				CE3A9BA21E607B28005D7E8F /* UIViewController.swift in Sources */,
+				CE228AE01EF2FE1E00097B19 /* UIFont.swift in Sources */,
 				B9F63CC21D5CE7FA00D09C1D /* Identifiable.swift in Sources */,
 				CE3A9B9E1E607B28005D7E8F /* UITextField.swift in Sources */,
 				CE3A9B941E607B28005D7E8F /* Timer.swift in Sources */,

--- a/Core/Extensions/UIKit/UIFont.swift
+++ b/Core/Extensions/UIKit/UIFont.swift
@@ -1,0 +1,64 @@
+//
+//  UIFont.swift
+//  Core
+//
+//  Created by Daniela Riesgo on 6/15/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import Foundation
+
+public protocol UIFontProvider {
+
+    /**
+     Returns a valid font name associated with the font text style specified.
+     By default, returns the font name of the font returned by
+     `UIFont.preferredFont(forTextStyle:)`.
+
+     - parameter style: A UIFontTextStyle.
+
+     - seealso: `UIFont.preferredFont(forTextStyle:)`.
+     */
+    func appFontName(for style: UIFontTextStyle) -> String
+
+}
+
+public extension UIFontProvider {
+
+    public func appFontName(for style: UIFontTextStyle) -> String {
+        return UIFont.preferredFont(forTextStyle: style).fontName
+    }
+
+}
+
+fileprivate class DefaultFontProvider: UIFontProvider {}
+
+public extension UIFont {
+
+    /**
+     UIFontProvider used to get the fonts associated with UIFontTextStyles.
+    */
+    public static var fontProvider: UIFontProvider? {
+        get {
+            return getAssociatedObject(self, key: &fontProviderKey)
+        }
+
+        set {
+            setAssociatedObject(self, key: &fontProviderKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    public static func appFont(for style: UIFontTextStyle) -> UIFont {
+        let defaultFont = UIFont.preferredFont(forTextStyle: style)
+        let provider = fontProvider ?? DefaultFontProvider()
+        let fontName = provider.appFontName(for: style)
+        if let newFont = UIFont(name: fontName, size: defaultFont.pointSize) {
+            return newFont
+        } else {
+            fatalError("The font name associated with UIFontTextStyle \(style) is not valid.")
+        }
+    }
+
+}
+
+private var fontProviderKey: UInt8 = 0

--- a/Core/Extensions/UIKit/UIFont.swift
+++ b/Core/Extensions/UIKit/UIFont.swift
@@ -54,9 +54,8 @@ public extension UIFont {
         let fontName = provider.appFontName(for: style)
         if let newFont = UIFont(name: fontName, size: defaultFont.pointSize) {
             return newFont
-        } else {
-            fatalError("The font name associated with UIFontTextStyle \(style) is not valid.")
         }
+        fatalError("The font name associated with UIFontTextStyle \(style) is not valid.")
     }
 
 }

--- a/Core/Extensions/UIKit/UILabel.swift
+++ b/Core/Extensions/UIKit/UILabel.swift
@@ -18,6 +18,10 @@ public extension UILabel {
 
      When the style is set, the corresponding font will be set.
      If the font is changed, then the label will have no specific font text style.
+     
+     - warning: Setting this property may arise a runtime error if the font name returned by
+     `UIFont.appFontName(for:)` is not valid.
+     - seealso: UIFont.appFontName(for:).
      */
     public var fontTextStyle: UIFontTextStyle? {
         get {
@@ -31,7 +35,7 @@ public extension UILabel {
             }
             setAssociatedObject(self, key: &fontTextStyleKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             if let fontStyle = fontTextStyle {
-                font = UIFont.preferredFont(forTextStyle: fontStyle)
+                font = UIFont.appFont(for: fontStyle)
                 let disposable = reactive.signal(forKeyPath: "font")
                     .take(during: self.reactive.lifetime)
                     .take(first: 1)

--- a/Core/Extensions/UIKit/UILabel.swift
+++ b/Core/Extensions/UIKit/UILabel.swift
@@ -1,40 +1,24 @@
 //
-//  UITextFieldExtension.swift
+//  UILabel.swift
 //  Core
 //
-//  Created by Francisco Depascuali on 6/29/16.
-//  Copyright © 2016 Wolox. All rights reserved.
+//  Created by Daniela Riesgo on 6/5/17.
+//  Copyright © 2017 Wolox. All rights reserved.
 //
 
 import Foundation
-import ReactiveSwift
 import ReactiveCocoa
+import ReactiveSwift
 
-public extension UITextField {
-    
-    /**
-     nextTextField is intended to be used in a form, so that the delegate uses it, for example, in the textFieldShouldReturn method.
-     
-     - warning: Avoid setting nextTextField in the didSet hook of an outlet.
-                Override awakeFromNib() of the containing view in that case.
-     */
-    public var nextTextField: UITextField? {
-        get {
-            return getAssociatedObject(self, key: &nextTextFieldKey)
-        }
-        
-        set {
-            setAssociatedObject(self, key: &nextTextFieldKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+public extension UILabel {
 
     /**
      fontTextStyle is intended to be used instead of setting the font style by taking advantage of
-     `UIFont.preferredFont(forTextStyle:)` to manage your app's fonts.
-     
+     `UIFont.preferredFont(forTextStyle:)` to manage your apps fonts.
+
      When the style is set, the corresponding font will be set.
-     If the font is changed, then the textfield will have no specific font text style.
-    */
+     If the font is changed, then the label will have no specific font text style.
+     */
     public var fontTextStyle: UIFontTextStyle? {
         get {
             return getAssociatedObject(self, key: &fontTextStyleKey)
@@ -64,6 +48,5 @@ public extension UITextField {
 
 }
 
-private var nextTextFieldKey: UInt8 = 0
-private var fontTextStyleKey: UInt8 = 1
-private var fontTextStyleDisposableKey: UInt8 = 2
+private var fontTextStyleKey: UInt8 = 0
+private var fontTextStyleDisposableKey: UInt8 = 1

--- a/Core/Extensions/UIKit/UITextField.swift
+++ b/Core/Extensions/UIKit/UITextField.swift
@@ -34,6 +34,10 @@ public extension UITextField {
      
      When the style is set, the corresponding font will be set.
      If the font is changed, then the textfield will have no specific font text style.
+     
+     - warning: Setting this property may arise a runtime error if the font name returned by
+        `UIFont.appFontName(for:)` is not valid.
+     - seealso: UIFont.appFontName(for:).
     */
     public var fontTextStyle: UIFontTextStyle? {
         get {
@@ -47,7 +51,7 @@ public extension UITextField {
             }
             setAssociatedObject(self, key: &fontTextStyleKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             if let fontStyle = fontTextStyle {
-                font = UIFont.preferredFont(forTextStyle: fontStyle)
+                font = UIFont.appFont(for: fontStyle)
                 let disposable = reactive.signal(forKeyPath: "font")
                     .take(during: self.reactive.lifetime)
                     .take(first: 1)

--- a/Core/Extensions/UIKit/UITextField.swift
+++ b/Core/Extensions/UIKit/UITextField.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import ReactiveSwift
+import ReactiveCocoa
 
 public extension UITextField {
     
@@ -25,6 +27,30 @@ public extension UITextField {
             setAssociatedObject(self, key: &nextTextFieldKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
+
+    public var fontTextStyle: UIFontTextStyle? {
+        get {
+            return getAssociatedObject(self, key: &fontTextStyleKey)
+        }
+        set {
+            setAssociatedObject(self, key: &fontTextStyleKey, value: newValue, policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            if let fontStyle = fontTextStyle {
+                font = UIFont.preferredFont(forTextStyle: fontStyle)
+            }
+            reactive.signal(forKeyPath: "font")
+                .take(during: self.reactive.lifetime)
+                .take(first: 1)
+                .observeValues { [unowned self] _ in
+                    setAssociatedObject(self,
+                                        key: &fontTextStyleKey,
+                                        value: UIFontTextStyle?.none,
+                                        policy: .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+        }
+    }
+
 }
 
 private var nextTextFieldKey: UInt8 = 0
+private var fontTextStyleKey: UInt8 = 0
+

--- a/CoreTests/Extensions/UIKit/UILabelSpec.swift
+++ b/CoreTests/Extensions/UIKit/UILabelSpec.swift
@@ -12,9 +12,25 @@ import Quick
 import Nimble
 import Core
 
+fileprivate class MyFontProvider: UIFontProvider {
+
+    func appFontName(for style: UIFontTextStyle) -> String {
+        switch style {
+        case UIFontTextStyle.headline: return "Helvetica-Bold"
+        case UIFontTextStyle.title1: return "jwdbf"
+        default: return "Helvetica"
+        }
+    }
+
+}
+
 public class UILabelSpec: QuickSpec {
 
     override public func spec() {
+
+        beforeSuite {
+            UIFont.fontProvider = MyFontProvider()
+        }
 
         describe("#fontTextStyle") {
 
@@ -63,7 +79,7 @@ public class UILabelSpec: QuickSpec {
 
                     beforeEach {
                         label.fontTextStyle = .body
-                        label.fontTextStyle = .title1
+                        label.fontTextStyle = .title2
                         label.font = UIFont.systemFont(ofSize: 30)
                     }
 
@@ -77,31 +93,61 @@ public class UILabelSpec: QuickSpec {
 
             describe("set") {
 
-                beforeEach {
-                    label.fontTextStyle = .body
-                }
-
                 context("When a style is set") {
-                    
-                    it("should change the fontTextStyle") {
-                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.body))
+
+                    context("that has a custom font name") {
+
+                        beforeEach {
+                            label.fontTextStyle = .headline
+                        }
+
+                        it("should change the fontTextStyle") {
+                            expect(label.fontTextStyle).to(equal(UIFontTextStyle.headline))
+                        }
+
+                        it("should change the font as specified in appFontName(for:)") {
+                            expect(label.font.pointSize).to(equal(UIFont.preferredFont(forTextStyle: .headline).pointSize))
+                            expect(label.font.fontName).to(equal("Helvetica-Bold"))
+                        }
+
                     }
-                    
-                    it("should change the font as well") {
-                        expect(label.font).to(equal(UIFont.preferredFont(forTextStyle: .body)))
+
+                    context("that has the base font") {
+
+                        beforeEach {
+                            label.fontTextStyle = .body
+                        }
+
+                        it("should change the fontTextStyle") {
+                            expect(label.fontTextStyle).to(equal(UIFontTextStyle.body))
+                        }
+
+                        it("should change the font as specified in appFontName(for:)") {
+                            expect(label.font.pointSize).to(equal(UIFont.preferredFont(forTextStyle: .body).pointSize))
+                            expect(label.font.fontName).to(equal("Helvetica"))
+                        }
+
                     }
-                    
+
+                    context("that is associated with an invalid font name") {
+
+                        it("should throw a runtime error") {
+                            expect(label.fontTextStyle = .title1).to(throwAssertion())
+                        }
+
+                    }
+
                 }
 
                 context("When a style is set after another one") {
 
                     beforeEach {
                         label.fontTextStyle = .body
-                        label.fontTextStyle = .title1
+                        label.fontTextStyle = .title2
                     }
 
                     it("should return the new textStyle") {
-                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title2))
                     }
                     
                 }
@@ -111,11 +157,11 @@ public class UILabelSpec: QuickSpec {
                     beforeEach {
                         label.fontTextStyle = .body
                         label.font = UIFont.systemFont(ofSize: 30)
-                        label.fontTextStyle = .title1
+                        label.fontTextStyle = .title2
                     }
 
                     it("should return the new textStyle") {
-                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title2))
                     }
                     
                 }

--- a/CoreTests/Extensions/UIKit/UILabelSpec.swift
+++ b/CoreTests/Extensions/UIKit/UILabelSpec.swift
@@ -1,0 +1,129 @@
+//
+//  UILabelSpec.swift
+//  Core
+//
+//  Created by Daniela Riesgo on 6/5/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import Foundation
+
+import Quick
+import Nimble
+import Core
+
+public class UILabelSpec: QuickSpec {
+
+    override public func spec() {
+
+        describe("#fontTextStyle") {
+
+            var label: UILabel!
+
+            beforeEach {
+                label = UILabel()
+            }
+
+            describe("get") {
+
+                context("When a style was set") {
+
+                    beforeEach {
+                        label.fontTextStyle = .body
+                    }
+
+                    it("should return that style") {
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.body))
+                    }
+
+                }
+
+                context("When no style was set") {
+
+                    it("should return .none") {
+                        expect(label.fontTextStyle).to(beNil())
+                    }
+
+                }
+
+                context("When a style was set but then font property was changed") {
+
+                    beforeEach {
+                        label.fontTextStyle = .body
+                        label.font = UIFont.systemFont(ofSize: 30)
+                    }
+
+                    it("should return .none") {
+                        expect(label.fontTextStyle).to(beNil())
+                    }
+
+                }
+
+                context("When a font was set after setting various styles") {
+
+                    beforeEach {
+                        label.fontTextStyle = .body
+                        label.fontTextStyle = .title1
+                        label.font = UIFont.systemFont(ofSize: 30)
+                    }
+
+                    it("should return .none") {
+                        expect(label.fontTextStyle).to(beNil())
+                    }
+
+                }
+
+            }
+
+            describe("set") {
+
+                beforeEach {
+                    label.fontTextStyle = .body
+                }
+
+                context("When a style is set") {
+                    
+                    it("should change the fontTextStyle") {
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.body))
+                    }
+                    
+                    it("should change the font as well") {
+                        expect(label.font).to(equal(UIFont.preferredFont(forTextStyle: .body)))
+                    }
+                    
+                }
+
+                context("When a style is set after another one") {
+
+                    beforeEach {
+                        label.fontTextStyle = .body
+                        label.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
+                }
+
+                context("When a style is set after font property was changed") {
+
+                    beforeEach {
+                        label.fontTextStyle = .body
+                        label.font = UIFont.systemFont(ofSize: 30)
+                        label.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(label.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
+                }
+                
+            }
+            
+        }
+        
+    }
+    
+}

--- a/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
+++ b/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
@@ -105,33 +105,6 @@ public class UITextFieldSpec: QuickSpec {
                     
                 }
 
-                context("When a style was set after font property was changed") {
-
-                    beforeEach {
-                        textField.fontTextStyle = .body
-                        textField.font = UIFont.systemFont(ofSize: 30)
-                        textField.fontTextStyle = .title1
-                    }
-
-                    it("should return the new textStyle") {
-                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
-                    }
-                    
-                }
-
-                context("When a style was set after another one") {
-
-                    beforeEach {
-                        textField.fontTextStyle = .body
-                        textField.fontTextStyle = .title1
-                    }
-
-                    it("should return the new textStyle") {
-                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
-                    }
-                    
-                }
-
                 context("When a font was set after setting various styles") {
 
                     beforeEach {
@@ -164,6 +137,33 @@ public class UITextFieldSpec: QuickSpec {
                         expect(textField.font).to(equal(UIFont.preferredFont(forTextStyle: .body)))
                     }
 
+                }
+
+                context("When a style was set after another one") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
+                }
+
+                context("When a style was set after font property was changed") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.font = UIFont.systemFont(ofSize: 30)
+                        textField.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
                 }
 
             }

--- a/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
+++ b/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
@@ -12,9 +12,25 @@ import Quick
 import Nimble
 import Core
 
+fileprivate class MyFontProvider: UIFontProvider {
+
+    func appFontName(for style: UIFontTextStyle) -> String {
+        switch style {
+        case UIFontTextStyle.headline: return "Helvetica-Bold"
+        case UIFontTextStyle.title1: return "jwdbf"
+        default: return "Helvetica"
+        }
+    }
+    
+}
+
 public class UITextFieldSpec: QuickSpec {
     
     override public func spec() {
+
+        beforeSuite {
+            UIFont.fontProvider = MyFontProvider()
+        }
 
         describe("#nextTextField") {
             
@@ -109,7 +125,7 @@ public class UITextFieldSpec: QuickSpec {
 
                     beforeEach {
                         textField.fontTextStyle = .body
-                        textField.fontTextStyle = .title1
+                        textField.fontTextStyle = .headline
                         textField.font = UIFont.systemFont(ofSize: 30)
                     }
 
@@ -123,45 +139,75 @@ public class UITextFieldSpec: QuickSpec {
 
             describe("set") {
 
-                beforeEach {
-                    textField.fontTextStyle = .body
-                }
-
                 context("When a style is set") {
 
-                    it("should change the fontTextStyle") {
-                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.body))
+                    context("that has a custom font name") {
+
+                        beforeEach {
+                            textField.fontTextStyle = .headline
+                        }
+
+                        it("should change the fontTextStyle") {
+                            expect(textField.fontTextStyle).to(equal(UIFontTextStyle.headline))
+                        }
+
+                        it("should change the font as specified in appFontName(for:)") {
+                            expect(textField.font?.pointSize).to(equal(UIFont.preferredFont(forTextStyle: .headline).pointSize))
+                            expect(textField.font?.fontName).to(equal("Helvetica-Bold"))
+                        }
+
                     }
 
-                    it("should change the font as well") {
-                        expect(textField.font).to(equal(UIFont.preferredFont(forTextStyle: .body)))
+                    context("that has the base font") {
+
+                        beforeEach {
+                            textField.fontTextStyle = .body
+                        }
+
+                        it("should change the fontTextStyle") {
+                            expect(textField.fontTextStyle).to(equal(UIFontTextStyle.body))
+                        }
+
+                        it("should change the font as specified in appFontName(for:)") {
+                            expect(textField.font?.pointSize).to(equal(UIFont.preferredFont(forTextStyle: .body).pointSize))
+                            expect(textField.font?.fontName).to(equal("Helvetica"))
+                        }
+
                     }
 
-                }
-
-                context("When a style was set after another one") {
-
-                    beforeEach {
-                        textField.fontTextStyle = .body
-                        textField.fontTextStyle = .title1
+                    context("that is associated with an invalid font name") {
+                        
+                        it("should throw a runtime error") {
+                            expect(textField.fontTextStyle = .title1).to(throwAssertion())
+                        }
+                        
                     }
 
-                    it("should return the new textStyle") {
-                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    context("When a style is set after another one") {
+
+                        beforeEach {
+                            textField.fontTextStyle = .body
+                            textField.fontTextStyle = .title2
+                        }
+
+                        it("should return the new textStyle") {
+                            expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title2))
+                        }
+
                     }
-                    
-                }
 
-                context("When a style was set after font property was changed") {
+                    context("When a style is set after font property was changed") {
 
-                    beforeEach {
-                        textField.fontTextStyle = .body
-                        textField.font = UIFont.systemFont(ofSize: 30)
-                        textField.fontTextStyle = .title1
-                    }
+                        beforeEach {
+                            textField.fontTextStyle = .body
+                            textField.font = UIFont.systemFont(ofSize: 30)
+                            textField.fontTextStyle = .title2
+                        }
 
-                    it("should return the new textStyle") {
-                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                        it("should return the new textStyle") {
+                            expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title2))
+                        }
+                        
                     }
                     
                 }

--- a/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
+++ b/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
@@ -55,9 +55,80 @@ public class UITextFieldSpec: QuickSpec {
                         expect(textField.nextTextField).toNot(beNil())
                         expect(textField.nextTextField!).to(equal(otherTextField))
                     }
+
                 }
+
             }
             
         }
+
+        describe("#fontTextStyle") {
+
+            var textField: UITextField!
+
+            beforeEach {
+                textField = UITextField()
+            }
+
+            describe("get") {
+
+                context("When a style was set") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                    }
+
+                    it("should return that style") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.body))
+                    }
+                    
+                }
+
+                context("When no style was set") {
+
+                    it("should return .none") {
+                        expect(textField.fontTextStyle).to(beNil())
+                    }
+                    
+                }
+
+                context("When a style was set but then font property was changed") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.font = UIFont.systemFont(ofSize: 30)
+                    }
+
+                    it("should return that style") {
+                        expect(textField.fontTextStyle).to(beNil())
+                    }
+                    
+                }
+
+            }
+
+            describe("set") {
+
+                beforeEach {
+                    textField.fontTextStyle = .body
+                }
+
+                context("When a style is set") {
+
+                    it("should change the fontTextStyle") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.body))
+                    }
+
+                    it("should change the font as well") {
+                        expect(textField.font).to(equal(UIFont.preferredFont(forTextStyle: .body)))
+                    }
+
+                }
+
+            }
+
+        }
+
     }
+
 }

--- a/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
+++ b/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
@@ -105,6 +105,47 @@ public class UITextFieldSpec: QuickSpec {
                     
                 }
 
+                context("When a style was set after font property was changed") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.font = UIFont.systemFont(ofSize: 30)
+                        textField.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
+                }
+
+                context("When a style was set after another one") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.fontTextStyle = .title1
+                    }
+
+                    it("should return the new textStyle") {
+                        expect(textField.fontTextStyle).to(equal(UIFontTextStyle.title1))
+                    }
+                    
+                }
+
+                context("When a font was set after setting various styles") {
+
+                    beforeEach {
+                        textField.fontTextStyle = .body
+                        textField.fontTextStyle = .title1
+                        textField.font = UIFont.systemFont(ofSize: 30)
+                    }
+
+                    it("should return .none") {
+                        expect(textField.fontTextStyle).to(beNil())
+                    }
+                    
+                }
+
             }
 
             describe("set") {

--- a/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
+++ b/CoreTests/Extensions/UIKit/UITextFieldSpec.swift
@@ -99,7 +99,7 @@ public class UITextFieldSpec: QuickSpec {
                         textField.font = UIFont.systemFont(ofSize: 30)
                     }
 
-                    it("should return that style") {
+                    it("should return .none") {
                         expect(textField.fontTextStyle).to(beNil())
                     }
                     


### PR DESCRIPTION
## Summary ##

Adding a `fontTextStyle` property to textfields.
It's a way to encourage the use of `UIFontTextStyle` which was passed in the iOS channel because of [this](https://developer.apple.com/reference/uikit/uifont/1619030-preferredfont) specific function.

We usually create a UIFont extension with our fonts for the project. But this structure already takes care of that. We can override UIFont's `preferredFont(forTextStyle:)` and use text styles like design normally do: body, title, title1, etc. And we can create our own font text styles if not, because it's a struct and not an enum.

From tests, it seems to work.

If you like it, we could add it to UILabel too I think.