### PR TITLE
Add UIViewController extension to configure navigation bar

### DIFF
--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -47,19 +47,19 @@ public extension UIViewController {
     
 }
 
-//MARK: - Navigation Bar
+// MARK: - Navigation Bar
 
 public extension UIViewController {
 
     /**
-     Configures the navigation bar to have a back button with a particular image.
-     - parameter backImage: The image of the back button.
+     Configures the navigation bar to have a particular image as back button.
+     - parameter image: The image of the back button.
      - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
      */
-    func configureBasicNavigationBarWithBackButton(backImage: UIImage) {
+    public func setNavigationBarBackButton(image: UIImage) {
         navigationController!.navigationBar.topItem?.title = ""
-        navigationController!.navigationBar.backIndicatorImage = backImage
-        navigationController!.navigationBar.backIndicatorTransitionMaskImage = backImage
+        navigationController!.navigationBar.backIndicatorImage = image
+        navigationController!.navigationBar.backIndicatorTransitionMaskImage = image
     }
     
     /**
@@ -67,7 +67,7 @@ public extension UIViewController {
      - parameter color: The new color of the navigation bar.
      - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
      */
-    func configureNavigationBarColor(_ color: UIColor) {
+    public func setNavigationBarColor(_ color: UIColor) {
         navigationController!.navigationBar.barTintColor = color
     }
     
@@ -75,7 +75,7 @@ public extension UIViewController {
      Sets a collection of buttons as the navigation bar left buttons.
      - parameter buttons: the Array of buttons to use.
      */
-    func configureNavigationLeftButtons(_ buttons: [UIBarButtonItem]) {
+    public func setNavigationLeftButtons(_ buttons: [UIBarButtonItem]) {
         navigationItem.leftBarButtonItems = buttons
     }
     
@@ -83,17 +83,17 @@ public extension UIViewController {
      Sets a collection of buttons as the navigation bar right buttons.
      - parameter buttons: the Array of buttons to use.
      */
-    func configureNavigationRightButtons(_ buttons: [UIBarButtonItem]) {
+    public func setNavigationRightButtons(_ buttons: [UIBarButtonItem]) {
         navigationItem.rightBarButtonItems = buttons
     }
 
     /**
      Adds and configures a label to use as title of the navigation bar.
      - parameter title: the string of the label.
-     - parameter font: the font to use for the label. Default: .systemFont size 18
-     - parameter color: the color of the text. Default: .white
+     - parameter font: the font to use for the label.
+     - parameter color: the color of the text.
      */
-    func setNavBarTitle(_ title: String, font: UIFont, color: UIColor) {
+    public func setNavigationBarTitle(_ title: String, font: UIFont, color: UIColor) {
         let label = UILabel(frame: .zero)
         label.backgroundColor = .clear
         label.font = font

--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -54,7 +54,8 @@ public extension UIViewController {
     /**
      Configures the navigation bar to have a particular image as back button.
      - parameter image: The image of the back button.
-     - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
+     - warning: This function must be called when self is inside a navigation controller. 
+            If not it will arise a runtime nil-force-unwrapping error.
      */
     public func setNavigationBarBackButton(image: UIImage) {
         navigationController!.navigationBar.topItem?.title = ""
@@ -65,7 +66,8 @@ public extension UIViewController {
     /**
      Configures the navigation bar color.
      - parameter color: The new color of the navigation bar.
-     - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
+     - warning: This function must be called when self is inside a navigation controller. 
+            If not it will arise a runtime nil-force-unwrapping error.
      */
     public func setNavigationBarColor(_ color: UIColor) {
         navigationController!.navigationBar.barTintColor = color

--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -110,4 +110,12 @@ public extension UIViewController {
         navigationItem.titleView = label
     }
     
+    /**
+     Adds an ImageView with the image passed as the titleView of the navigation bar.
+     - parameter image: The image to set as title.
+     */
+    public func setNavigationBarTitleImage(_ image: UIImage) {
+        navigationItem.titleView = UIImageView(image: image)
+    }
+    
 }

--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -47,11 +47,14 @@ public extension UIViewController {
     
 }
 
+//MARK: - Navigation Bar
+
 public extension UIViewController {
 
     /**
-     Configures the navigation bar to have a back button.
+     Configures the navigation bar to have a back button with a particular image.
      - parameter backImage: The image of the back button.
+     - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
      */
     func configureBasicNavigationBarWithBackButton(backImage: UIImage) {
         navigationController!.navigationBar.topItem?.title = ""
@@ -62,6 +65,7 @@ public extension UIViewController {
     /**
      Configures the navigation bar color.
      - parameter color: The new color of the navigation bar.
+     - warning: This function must be called when self is inside a navigation controller. If not it will arise a runtime nil-force-unwrapping error.
      */
     func configureNavigationBarColor(_ color: UIColor) {
         navigationController!.navigationBar.barTintColor = color
@@ -89,7 +93,7 @@ public extension UIViewController {
      - parameter font: the font to use for the label. Default: .systemFont size 18
      - parameter color: the color of the text. Default: .white
      */
-    func setNavBarTitle(_ title: String, font: UIFont = .systemFont(ofSize: 18), color: UIColor = .white) {
+    func setNavBarTitle(_ title: String, font: UIFont, color: UIColor) {
         let label = UILabel(frame: .zero)
         label.backgroundColor = .clear
         label.font = font

--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -55,22 +55,26 @@ public extension UIViewController {
      Configures the navigation bar to have a particular image as back button.
      - parameter image: The image of the back button.
      - warning: This function must be called when self is inside a navigation controller. 
-            If not it will arise a runtime nil-force-unwrapping error.
+            If not it will arise a runtime fatal error.
      */
     public func setNavigationBarBackButton(image: UIImage) {
-        navigationController!.navigationBar.topItem?.title = ""
-        navigationController!.navigationBar.backIndicatorImage = image
-        navigationController!.navigationBar.backIndicatorTransitionMaskImage = image
+        guard let navigationController = navigationController else { fatalError("There is no navigation controller.") }
+        
+        navigationController.navigationBar.topItem?.title = ""
+        navigationController.navigationBar.backIndicatorImage = image
+        navigationController.navigationBar.backIndicatorTransitionMaskImage = image
     }
     
     /**
      Configures the navigation bar color.
      - parameter color: The new color of the navigation bar.
      - warning: This function must be called when self is inside a navigation controller. 
-            If not it will arise a runtime nil-force-unwrapping error.
+            If not it will arise a runtime fatal error.
      */
     public func setNavigationBarColor(_ color: UIColor) {
-        navigationController!.navigationBar.barTintColor = color
+        guard let navigationController = navigationController else { fatalError("There is no navigation controller.") }
+        
+        navigationController.navigationBar.barTintColor = color
     }
     
     /**

--- a/Core/Extensions/UIKit/UIViewController.swift
+++ b/Core/Extensions/UIKit/UIViewController.swift
@@ -46,3 +46,58 @@ public extension UIViewController {
     }
     
 }
+
+public extension UIViewController {
+
+    /**
+     Configures the navigation bar to have a back button.
+     - parameter backImage: The image of the back button.
+     */
+    func configureBasicNavigationBarWithBackButton(backImage: UIImage) {
+        navigationController!.navigationBar.topItem?.title = ""
+        navigationController!.navigationBar.backIndicatorImage = backImage
+        navigationController!.navigationBar.backIndicatorTransitionMaskImage = backImage
+    }
+    
+    /**
+     Configures the navigation bar color.
+     - parameter color: The new color of the navigation bar.
+     */
+    func configureNavigationBarColor(_ color: UIColor) {
+        navigationController!.navigationBar.barTintColor = color
+    }
+    
+    /**
+     Sets a collection of buttons as the navigation bar left buttons.
+     - parameter buttons: the Array of buttons to use.
+     */
+    func configureNavigationLeftButtons(_ buttons: [UIBarButtonItem]) {
+        navigationItem.leftBarButtonItems = buttons
+    }
+    
+    /**
+     Sets a collection of buttons as the navigation bar right buttons.
+     - parameter buttons: the Array of buttons to use.
+     */
+    func configureNavigationRightButtons(_ buttons: [UIBarButtonItem]) {
+        navigationItem.rightBarButtonItems = buttons
+    }
+
+    /**
+     Adds and configures a label to use as title of the navigation bar.
+     - parameter title: the string of the label.
+     - parameter font: the font to use for the label. Default: .systemFont size 18
+     - parameter color: the color of the text. Default: .white
+     */
+    func setNavBarTitle(_ title: String, font: UIFont = .systemFont(ofSize: 18), color: UIColor = .white) {
+        let label = UILabel(frame: .zero)
+        label.backgroundColor = .clear
+        label.font = font
+        label.textColor = color
+        label.adjustsFontSizeToFitWidth = true
+        label.text = title
+        label.sizeToFit()
+        navigationItem.titleView = label
+    }
+    
+}


### PR DESCRIPTION
## Summary ##
**Issue**: https://github.com/Wolox/wolmo-core-ios/issues/67

Added an extension of UIViewController to be able to configure several aspects of the navigation bar: Adding a back button, changing the bar tint color, setting right and left buttons and using a label as the title.
