### PR TITLE
Fixing error with localizing and formatting strings

### DIFF
--- a/Core.xcodeproj/project.pbxproj
+++ b/Core.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		CE3A9BA11E607B28005D7E8F /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B8C1E607B28005D7E8F /* UIView.swift */; };
 		CE3A9BA21E607B28005D7E8F /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A9B8D1E607B28005D7E8F /* UIViewController.swift */; };
 		CE80E0F11E82D1F9005C300E /* PathAppendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80E0F01E82D1F9005C300E /* PathAppendable.swift */; };
+		CE983D471F913350004E8712 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE983D461F913350004E8712 /* Localizable.strings */; };
 		CED934851E8456480017CF96 /* UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED934841E8456480017CF96 /* UICollectionView.swift */; };
 		CEE9BFB41E8986D400D0E65D /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9BFA51E8986D400D0E65D /* ArraySpec.swift */; };
 		CEE9BFB51E8986D400D0E65D /* CollectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9BFA61E8986D400D0E65D /* CollectionSpec.swift */; };
@@ -182,6 +183,7 @@
 		CE3A9B8C1E607B28005D7E8F /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		CE3A9B8D1E607B28005D7E8F /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		CE80E0F01E82D1F9005C300E /* PathAppendable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathAppendable.swift; sourceTree = "<group>"; };
+		CE983D461F913350004E8712 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		CED934841E8456480017CF96 /* UICollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionView.swift; sourceTree = "<group>"; };
 		CEE9BFA51E8986D400D0E65D /* ArraySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySpec.swift; sourceTree = "<group>"; };
 		CEE9BFA61E8986D400D0E65D /* CollectionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionSpec.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				CEE9BFC11E8986DC00D0E65D /* Utilities */,
 				CEE9BFA31E8986D400D0E65D /* Extensions */,
 				9D896AC91CDE3EC5008B0E5F /* Info.plist */,
+				CE983D461F913350004E8712 /* Localizable.strings */,
 			);
 			path = CoreTests;
 			sourceTree = "<group>";
@@ -595,6 +598,7 @@
 				CE1186961EA7C70700105D6F /* NibLoadableCollectionView.xib in Resources */,
 				CE1186A81EA7EF2E00105D6F /* NibLoadableUITableView.xib in Resources */,
 				2D9229821F5D9BF5004F9A80 /* Assets.xcassets in Resources */,
+				CE983D471F913350004E8712 /* Localizable.strings in Resources */,
 				CE1186A61EA7E2A200105D6F /* NibLoadableUICollectionView.xib in Resources */,
 				CE1186981EA7C7F800105D6F /* NibLoadableCollectionCell.xib in Resources */,
 			);

--- a/Core/Extensions/Foundation/String.swift
+++ b/Core/Extensions/Foundation/String.swift
@@ -20,8 +20,12 @@ public extension String {
      */
     public func localized(withArguments arguments: CVarArg..., bundle: Bundle = Bundle.main) -> String {
         let localized = NSLocalizedString(self, tableName: .none, bundle: bundle, value: "", comment: "")
-        if arguments.count > 0 {
-            return localized.format(with: arguments)
+        if arguments.isNotEmpty {
+            // Can't call .format(with:): https://stackoverflow.com/a/24024724
+            // Once inside the function, a CVarArg... becomes a [CVarArg]
+            // and when passing it on to another function that receives CVarArg,
+            // it interprets that you are passing only one CVarArg which is an array.
+            return String(format: localized, arguments: arguments)
         }
         return localized
     }

--- a/CoreTests/Extensions/Foundation/StringSpec.swift
+++ b/CoreTests/Extensions/Foundation/StringSpec.swift
@@ -15,6 +15,36 @@ public class StringSpec: QuickSpec {
     
     override public func spec() {
         
+        describe("localized()") {
+            // Don't know how to test it, since Bundle.main in simulator
+            // is not the one where the strings file is.
+        }
+        
+        describe("#localized(bundle:)") {
+            
+            it("should localize the string according to main bundle") {
+                let key = "some.example.key"
+                let localized = key.localized(bundle: Bundle(for: StringSpec.self))
+                expect(localized).to(equal("This is my localized string."))
+            }
+            
+        }
+        
+        describe("#localized(withArguments:)") {
+            // Don't know how to test it, since Bundle.main in simulator
+            // is not the one where the strings file is.
+        }
+        
+        describe("#localized(withArguments:bundle:)") {
+            
+            it("should localize the string and then format it with the arguments passed") {
+                let key = "some.example.formatting_key"
+                let result = key.localized(withArguments: 5, "Test", bundle: Bundle(for: StringSpec.self))
+                expect(result).to(equal("The number is 5, and my name Test."))
+            }
+            
+        }
+        
         describe("#format(with:)") {
             
             it("should returned the formatted string as expected") {

--- a/CoreTests/Localizable.strings
+++ b/CoreTests/Localizable.strings
@@ -1,0 +1,10 @@
+/* 
+  Localizable.strings
+  Core
+
+  Created by Daniela Riesgo on 10/13/17.
+  Copyright © 2017 Wolox. All rights reserved.
+*/
+
+"some.example.key" = "This is my localized string.";
+"some.example.formatting_key" = "The number is %i, and my name %@.";


### PR DESCRIPTION
## Summary ##

The `.localized(withArguments: 2, "hi")` didn't work.
You had to do:  `.localized().format(with: 2, "hi")`.

With this, it will work correctly. Left comment explaining why.
