### PR TITLE
String multiplier

### DIFF
--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -203,5 +203,4 @@ public extension String {
     public static func * (lhs: Int, rhs: String) -> String {
         return String(repeating: rhs, count: lhs)
     }
-    
 }

--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -203,4 +203,5 @@ public extension String {
     public static func * (lhs: Int, rhs: String) -> String {
         return String(repeating: rhs, count: lhs)
     }
+    
 }

--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -185,7 +185,7 @@ public extension String {
     }
     
     /**
-     Repeats string multiple times
+     Repeats a string multiple times
      
      - parameter lhs: string to repeat.
      - parameter rhs: number of times to repeat character.
@@ -195,7 +195,7 @@ public extension String {
     }
     
     /**
-     Repeats string multiple times
+     Repeats a string multiple times
      
      - parameter lhs: number of times to repeat character.
      - parameter rhs: string to repeat.

--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -188,7 +188,7 @@ public extension String {
      Repeats a string multiple times
      
      - parameter lhs: string to repeat.
-     - parameter rhs: number of times to repeat character.
+     - parameter rhs: number of times to repeat string.
      */
     public static func * (lhs: String, rhs: Int) -> String {
         return String(repeating: lhs, count: rhs)
@@ -197,7 +197,7 @@ public extension String {
     /**
      Repeats a string multiple times
      
-     - parameter lhs: number of times to repeat character.
+     - parameter lhs: number of times to repeat string.
      - parameter rhs: string to repeat.
      */
     public static func * (lhs: Int, rhs: String) -> String {

--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -185,7 +185,7 @@ public extension String {
     }
     
     /**
-     Repeats a string multiple times
+     Repeats a string multiple times.
      
      - parameter lhs: string to repeat.
      - parameter rhs: number of times to repeat string.
@@ -195,7 +195,7 @@ public extension String {
     }
     
     /**
-     Repeats a string multiple times
+     Repeats a string multiple times.
      
      - parameter lhs: number of times to repeat string.
      - parameter rhs: string to repeat.

--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -184,4 +184,23 @@ public extension String {
         return image
     }
     
+    /**
+     Repeats string multiple times
+     
+     - parameter lhs: string to repeat.
+     - parameter rhs: number of times to repeat character.
+     */
+    public static func * (lhs: String, rhs: Int) -> String {
+        return String(repeating: lhs, count: rhs)
+    }
+    
+    /**
+     Repeats string multiple times
+     
+     - parameter lhs: number of times to repeat character.
+     - parameter rhs: string to repeat.
+     */
+    public static func * (lhs: Int, rhs: String) -> String {
+        return String(repeating: rhs, count: lhs)
+    }
 }

--- a/WolmoCoreTests/Extensions/Foundation/StringSpec.swift
+++ b/WolmoCoreTests/Extensions/Foundation/StringSpec.swift
@@ -458,6 +458,51 @@ public class StringSpec: QuickSpec {
             
         }
         
+        describe("#*(lhs:rhs:)") {
+            
+            var string: String!
+            var numberOfTimes: Int!
+            
+            context("when the string is empty") {
+                
+                beforeEach {
+                    string = ""
+                    numberOfTimes = 3
+                }
+                
+                it("should return an empty string") {
+                    expect(string * numberOfTimes).to(equal(""))
+                }
+                
+            }
+            
+            context("when the string is on the left side") {
+                
+                beforeEach {
+                    string = "something"
+                    numberOfTimes = 3
+                }
+                
+                it("should return the original string repeated three times") {
+                    expect(string * numberOfTimes).to(equal("somethingsomethingsomething"))
+                }
+                
+            }
+            
+            context("when the string is on the right side") {
+                
+                beforeEach {
+                    string = "something"
+                    numberOfTimes = 3
+                }
+                
+                it("should return the original string repeated three times") {
+                    expect(numberOfTimes * string).to(equal("somethingsomethingsomething"))
+                }
+                
+            }
+        }
+        
     }
     // swiftlint:enable function_body_length
 


### PR DESCRIPTION
## Summary ##

This PR adds a method for multiplying a string with an asterisk, like Ruby does.

## Example ##

- `"Hello" * 3` should return `"HelloHelloHello"`