### PR TITLE
String multiplier

### DIFF
--- a/WolmoCore/Extensions/Foundation/String.swift
+++ b/WolmoCore/Extensions/Foundation/String.swift
@@ -184,4 +184,24 @@ public extension String {
         return image
     }
     
+    /**
+     Repeats a string multiple times.
+     
+     - parameter lhs: string to repeat.
+     - parameter rhs: number of times to repeat string.
+     */
+    public static func * (lhs: String, rhs: Int) -> String {
+        return String(repeating: lhs, count: rhs)
+    }
+    
+    /**
+     Repeats a string multiple times.
+     
+     - parameter lhs: number of times to repeat string.
+     - parameter rhs: string to repeat.
+     */
+    public static func * (lhs: Int, rhs: String) -> String {
+        return String(repeating: rhs, count: lhs)
+    }
+    
 }

--- a/WolmoCoreTests/Extensions/Foundation/StringSpec.swift
+++ b/WolmoCoreTests/Extensions/Foundation/StringSpec.swift
@@ -458,6 +458,51 @@ public class StringSpec: QuickSpec {
             
         }
         
+        describe("#*(lhs:rhs:)") {
+            
+            var string: String!
+            var numberOfTimes: Int!
+            
+            context("when the string is empty") {
+                
+                beforeEach {
+                    string = ""
+                    numberOfTimes = 3
+                }
+                
+                it("should return an empty string") {
+                    expect(string * numberOfTimes).to(equal(""))
+                }
+                
+            }
+            
+            context("when the string is on the left side") {
+                
+                beforeEach {
+                    string = "something"
+                    numberOfTimes = 3
+                }
+                
+                it("should return the original string repeated three times") {
+                    expect(string * numberOfTimes).to(equal("somethingsomethingsomething"))
+                }
+                
+            }
+            
+            context("when the string is on the right side") {
+                
+                beforeEach {
+                    string = "something"
+                    numberOfTimes = 3
+                }
+                
+                it("should return the original string repeated three times") {
+                    expect(numberOfTimes * string).to(equal("somethingsomethingsomething"))
+                }
+                
+            }
+        }
+        
     }
     // swiftlint:enable function_body_length
 


### PR DESCRIPTION
## Summary ##

This PR adds a method for multiplying a string with an asterisk, like Ruby does.

## Example ##

- `"Hello" * 3` should return `"HelloHelloHello"`