### PR TITLE
Swipe recognizer with closure

### DIFF
--- a/WolmoCore.xcodeproj/project.pbxproj
+++ b/WolmoCore.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0CB8BAB6216F835E00C8D6C1 /* ComparableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */; };
 		2D9229821F5D9BF5004F9A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B82058CE1EEF39230002D7D4 /* Assets.xcassets */; };
 		6508BE1B21C7CC3200622EE3 /* TapRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */; };
+		65215B3921D3C0FC0099863F /* SwipeRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B3821D3C0FC0099863F /* SwipeRecognizer.swift */; };
+		65215B3B21D3C2080099863F /* SwipeRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B3A21D3C2080099863F /* SwipeRecognizerSpec.swift */; };
 		656EDB2121CD3CBE0025DDA0 /* PinchRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */; };
 		656EDB2421CD3DCF0025DDA0 /* PinchRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */; };
 		65A2F8A121C7E2FC001F7190 /* TapRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */; };
@@ -198,6 +200,8 @@
 		0CB8BAB3216F82FF00C8D6C1 /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparableSpec.swift; sourceTree = "<group>"; };
 		6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizer.swift; sourceTree = "<group>"; };
+		65215B3821D3C0FC0099863F /* SwipeRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeRecognizer.swift; sourceTree = "<group>"; };
+		65215B3A21D3C2080099863F /* SwipeRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeRecognizerSpec.swift; sourceTree = "<group>"; };
 		656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizer.swift; sourceTree = "<group>"; };
 		656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizerSpec.swift; sourceTree = "<group>"; };
 		65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizerSpec.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 			children = (
 				6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */,
 				656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */,
+				65215B3821D3C0FC0099863F /* SwipeRecognizer.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -387,6 +392,7 @@
 			children = (
 				65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */,
 				656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */,
+				65215B3A21D3C2080099863F /* SwipeRecognizerSpec.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -903,6 +909,7 @@
 				656EDB2121CD3CBE0025DDA0 /* PinchRecognizer.swift in Sources */,
 				0CB88322216455D90073459D /* UIImageView.swift in Sources */,
 				B8CF9A8C1EE9EF6E0063F951 /* UIImage.swift in Sources */,
+				65215B3921D3C0FC0099863F /* SwipeRecognizer.swift in Sources */,
 				CEE9BFCE1E8986F700D0E65D /* Collection.swift in Sources */,
 				CE3A9B911E607B28005D7E8F /* Date.swift in Sources */,
 				CED934851E8456480017CF96 /* UICollectionView.swift in Sources */,
@@ -929,6 +936,7 @@
 				CEE9BFCB1E8986DC00D0E65D /* IdentifiableSpec.swift in Sources */,
 				CEE9BFB71E8986D400D0E65D /* DictionarySpec.swift in Sources */,
 				CEE9BFCC1E8986DC00D0E65D /* PathAppendableSpec.swift in Sources */,
+				65215B3B21D3C2080099863F /* SwipeRecognizerSpec.swift in Sources */,
 				CE1186941EA7A7C600105D6F /* GeneralSpec.swift in Sources */,
 				CEE9BFB91E8986D400D0E65D /* StringSpec.swift in Sources */,
 				CEEC51801EE5EE3400BC41FE /* UILabelSpec.swift in Sources */,

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
@@ -16,7 +16,7 @@ public extension UIView {
         static var swipeGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
     }
     
-    fileprivate typealias Action = (() -> Void)?
+    fileprivate typealias Action = ((UISwipeGestureRecognizer) -> Void)?
     
     // Set our computed property type to a closure
     fileprivate var swipeGestureRecognizerAction: Action? {
@@ -35,24 +35,26 @@ public extension UIView {
     /**
      Adds a swipe gesture recognizer that executes the closure when swiped
      
+     - Parameter numberOfTouchesRequired: The number of fingers that must swipe. Default is 1
+     - Parameter direction: The desired direction of the swipe. Multiple directions may be specified if they will result in the same behavior (for example, UITableView swipe delete). Default is right
      - Parameter action: The closure that will execute when the view is swiped
      */
     public func addSwipeGestureRecognizer(numberOfTouchesRequired: Int = 1,
                                           direction: UISwipeGestureRecognizerDirection = .right,
-                                          action: (() -> Void)?) {
-        self.isUserInteractionEnabled = true
-        self.swipeGestureRecognizerAction = action
+                                          action: ((UISwipeGestureRecognizer) -> Void)?) {
+        isUserInteractionEnabled = true
+        swipeGestureRecognizerAction = action
         let swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture))
         swipeGestureRecognizer.direction = direction
         swipeGestureRecognizer.numberOfTouchesRequired = numberOfTouchesRequired
-        self.addGestureRecognizer(swipeGestureRecognizer)
+        addGestureRecognizer(swipeGestureRecognizer)
     }
     
     // Every time the user swipes on the UIView, this function gets called,
     // which triggers the closure we stored
     @objc fileprivate func handleSwipeGesture(sender: UISwipeGestureRecognizer) {
-        if let action = self.swipeGestureRecognizerAction {
-            action?()
+        if let action = swipeGestureRecognizerAction {
+            action?(sender)
         } else {
             print("No action for the swipe gesture")
         }

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
@@ -1,0 +1,61 @@
+//
+//  SwipeRecognizer.swift
+//  WolmoCore
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+public extension UIView {
+    
+    // In order to create computed properties for extensions, we need a key to
+    // store and access the stored property
+    fileprivate struct AssociatedObjectKeys {
+        static var swipeGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
+    }
+    
+    fileprivate typealias Action = (() -> Void)?
+    
+    // Set our computed property type to a closure
+    fileprivate var swipeGestureRecognizerAction: Action? {
+        set {
+            if let newValue = newValue {
+                // Computed properties get stored as associated objects
+                objc_setAssociatedObject(self, &AssociatedObjectKeys.swipeGestureRecognizer, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            }
+        }
+        get {
+            let swipeGestureRecognizerActionInstance = objc_getAssociatedObject(self, &AssociatedObjectKeys.swipeGestureRecognizer) as? Action
+            return swipeGestureRecognizerActionInstance
+        }
+    }
+    
+    /**
+     Adds a swipe gesture recognizer that executes the closure when swiped
+     
+     - Parameter action: The closure that will execute when the view is swiped
+     */
+    public func addSwipeGestureRecognizer(numberOfTouchesRequired: Int = 1,
+                                          direction: UISwipeGestureRecognizerDirection = .right,
+                                          action: (() -> Void)?) {
+        self.isUserInteractionEnabled = true
+        self.swipeGestureRecognizerAction = action
+        let swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeGesture))
+        swipeGestureRecognizer.direction = direction
+        swipeGestureRecognizer.numberOfTouchesRequired = numberOfTouchesRequired
+        self.addGestureRecognizer(swipeGestureRecognizer)
+    }
+    
+    // Every time the user swipes on the UIView, this function gets called,
+    // which triggers the closure we stored
+    @objc fileprivate func handleSwipeGesture(sender: UISwipeGestureRecognizer) {
+        if let action = self.swipeGestureRecognizerAction {
+            action?()
+        } else {
+            print("No action for the swipe gesture")
+        }
+    }
+}
+

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,6 +33,9 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
+        _view.gestureLabel.addSwipeGestureRecognizer(direction: .left) {
+            print("Label swiped!")
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,7 +33,7 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
-        _view.gestureLabel.addSwipeGestureRecognizer(direction: .left) {
+        _view.gestureLabel.addSwipeGestureRecognizer(direction: .left) { recognizer in
             print("Label swiped!")
         }
     }

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
@@ -23,7 +23,9 @@ public class SwipeRecognizerSpec: QuickSpec {
             context("when addSwipeGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addSwipeGestureRecognizer { /* No action */ }
+                    view.addSwipeGestureRecognizer { recognizer ->
+                        // No action
+                    }
                 }
                 
                 it("should have injected a UISwipeGestureRecognizer into the view") {

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
@@ -23,7 +23,7 @@ public class SwipeRecognizerSpec: QuickSpec {
             context("when addSwipeGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addSwipeGestureRecognizer { recognizer ->
+                    view.addSwipeGestureRecognizer { recognizer in
                         // No action
                     }
                 }

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizerSpec.swift
@@ -1,0 +1,37 @@
+//
+//  SwipeRecognizerSpec.swift
+//  WolmoCoreTests
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+import Quick
+import Nimble
+import WolmoCore
+
+public class SwipeRecognizerSpec: QuickSpec {
+    
+    override public func spec() {
+        
+        describe("#addSwipeGestureRecognizer(Action:)") {
+            
+            var view: UIView!
+            
+            context("when addSwipeGestureRecognizer has been called") {
+                beforeEach {
+                    view = UIView()
+                    view.addSwipeGestureRecognizer { /* No action */ }
+                }
+                
+                it("should have injected a UISwipeGestureRecognizer into the view") {
+                    let swipeRecognizer = view.gestureRecognizers?.first as? UISwipeGestureRecognizer
+                    expect(swipeRecognizer).toNot(beNil())
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary ##

An extension for `UIView` that allows adding a `UISwipeGestureRecognizer` with a closure (instead of using a selector).

#### Examples
```Swift
myView.addSwipeGestureRecognizer { recognizer in
    print("View swiped!")
}
```


```Swift
myView.addSwipeGestureRecognizer(direction: .up) { recognizer in
    print("View swiped up!")
}
```

```Swift
myView.addSwipeGestureRecognizer(direction: [.left, .right]) { recognizer in
    print("View swiped left or right!")
}
```

```Swift
myView.addSwipeGestureRecognizer { recognizer in
    switch recognizer.state {
        ...
    }
}
```