### PR TITLE
Pan recognizer with closure

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -17,5 +17,4 @@ ignore:
   - WolmoCore/Extensions/UIKit/UIView/SafeLayout.swift
   - WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/*
   - WolmoCore/Extensions/UIKit/UIViewController.swift
-  - WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/*
   - WolmoCore/Extensions/Animations/*

--- a/.slather.yml
+++ b/.slather.yml
@@ -15,5 +15,6 @@ ignore:
   - WolmoCore/Extensions/UIKit/UIView/Borders.swift
   - WolmoCore/Extensions/UIKit/UIView/Gradient.swift
   - WolmoCore/Extensions/UIKit/UIView/SafeLayout.swift
+  - WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/*
   - WolmoCore/Extensions/UIKit/UIViewController.swift
   - WolmoCore/Extensions/Animations/*

--- a/WolmoCore.xcodeproj/project.pbxproj
+++ b/WolmoCore.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0CB8BAB6216F835E00C8D6C1 /* ComparableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */; };
 		2D9229821F5D9BF5004F9A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B82058CE1EEF39230002D7D4 /* Assets.xcassets */; };
 		6508BE1B21C7CC3200622EE3 /* TapRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */; };
+		65215B2D21D3AF0C0099863F /* PanRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B2C21D3AF0C0099863F /* PanRecognizer.swift */; };
+		65215B2F21D3AFD60099863F /* PanRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B2E21D3AFD60099863F /* PanRecognizerSpec.swift */; };
 		656EDB2121CD3CBE0025DDA0 /* PinchRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */; };
 		656EDB2421CD3DCF0025DDA0 /* PinchRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */; };
 		65A2F8A121C7E2FC001F7190 /* TapRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */; };
@@ -198,6 +200,8 @@
 		0CB8BAB3216F82FF00C8D6C1 /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparableSpec.swift; sourceTree = "<group>"; };
 		6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizer.swift; sourceTree = "<group>"; };
+		65215B2C21D3AF0C0099863F /* PanRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanRecognizer.swift; sourceTree = "<group>"; };
+		65215B2E21D3AFD60099863F /* PanRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanRecognizerSpec.swift; sourceTree = "<group>"; };
 		656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizer.swift; sourceTree = "<group>"; };
 		656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizerSpec.swift; sourceTree = "<group>"; };
 		65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizerSpec.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 			children = (
 				6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */,
 				656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */,
+				65215B2C21D3AF0C0099863F /* PanRecognizer.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -387,6 +392,7 @@
 			children = (
 				65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */,
 				656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */,
+				65215B2E21D3AFD60099863F /* PanRecognizerSpec.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -889,6 +895,7 @@
 				6508BE1B21C7CC3200622EE3 /* TapRecognizer.swift in Sources */,
 				B988B97C1D244D6300824685 /* AlertViewPresenter.swift in Sources */,
 				CE4F2CB82135ED9F007BB465 /* AddInto.swift in Sources */,
+				65215B2D21D3AF0C0099863F /* PanRecognizer.swift in Sources */,
 				B988B9731D244BAE00824685 /* AssociatedObject.swift in Sources */,
 				CE3A9B9C1E607B28005D7E8F /* UIColor.swift in Sources */,
 				CE1DDFDE209A646B007471A0 /* SimpleAnimation.swift in Sources */,
@@ -945,6 +952,7 @@
 				CE6E9A1E20C5A1CE0068CC7A /* UIFontSpec.swift in Sources */,
 				CE11868D1EA7A0E100105D6F /* UICollectionViewSpec.swift in Sources */,
 				CEE9BFBA1E8986D400D0E65D /* TimerSpec.swift in Sources */,
+				65215B2F21D3AFD60099863F /* PanRecognizerSpec.swift in Sources */,
 				CE11869E1EA7C9DE00105D6F /* Resources.swift in Sources */,
 				CEE9BFB51E8986D400D0E65D /* CollectionSpec.swift in Sources */,
 			);

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
@@ -1,0 +1,58 @@
+//
+//  PanRecognizer.swift
+//  WolmoCore
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+public extension UIView {
+    
+    // In order to create computed properties for extensions, we need a key to
+    // store and access the stored property
+    fileprivate struct AssociatedObjectKeys {
+        static var panGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
+    }
+    
+    fileprivate typealias Action = (() -> Void)?
+    
+    // Set our computed property type to a closure
+    fileprivate var panGestureRecognizerAction: Action? {
+        set {
+            if let newValue = newValue {
+                // Computed properties get stored as associated objects
+                objc_setAssociatedObject(self, &AssociatedObjectKeys.panGestureRecognizer, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            }
+        }
+        get {
+            let panGestureRecognizerActionInstance = objc_getAssociatedObject(self, &AssociatedObjectKeys.panGestureRecognizer) as? Action
+            return panGestureRecognizerActionInstance
+        }
+    }
+    
+    /**
+     Adds a pan gesture recognizer that executes the closure when panned
+     
+     - Parameter action: The closure that will execute when the view is panned
+     */
+    public func addPanGestureRecognizer(action: (() -> Void)?) {
+        self.isUserInteractionEnabled = true
+        self.panGestureRecognizerAction = action
+        let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+        self.addGestureRecognizer(panGestureRecognizer)
+    }
+    
+    // Every time the user pans on the UIView, this function gets called,
+    // which triggers the closure we stored
+    @objc fileprivate func handlePanGesture(sender: UIPanGestureRecognizer) {
+        if let action = self.panGestureRecognizerAction {
+            action?()
+        } else {
+            print("No action for the pan gesture")
+        }
+    }
+    
+}
+

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
@@ -16,7 +16,7 @@ public extension UIView {
         static var panGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
     }
     
-    fileprivate typealias Action = (() -> Void)?
+    fileprivate typealias Action = ((UIPanGestureRecognizer) -> Void)?
     
     // Set our computed property type to a closure
     fileprivate var panGestureRecognizerAction: Action? {
@@ -35,24 +35,26 @@ public extension UIView {
     /**
      Adds a pan gesture recognizer that executes the closure when panned
      
+     - Parameter minimumNumberOfTouches: The minimum number of touches required to match. Default is 1
+     - Parameter maximumNumberOfTouches: The maximum number of touches that can be down. Default is Int.max
      - Parameter action: The closure that will execute when the view is panned
      */
-    public func addPanGestureRecognizer(action: (() -> Void)?) {
-        self.isUserInteractionEnabled = true
-        self.panGestureRecognizerAction = action
+    public func addPanGestureRecognizer(minimumNumberOfTouches: Int = 1,
+                                        maximumNumberOfTouches: Int = .max,
+                                        action: ((UIPanGestureRecognizer) -> Void)?) {
+        isUserInteractionEnabled = true
+        panGestureRecognizerAction = action
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
-        self.addGestureRecognizer(panGestureRecognizer)
+        addGestureRecognizer(panGestureRecognizer)
     }
     
     // Every time the user pans on the UIView, this function gets called,
     // which triggers the closure we stored
     @objc fileprivate func handlePanGesture(sender: UIPanGestureRecognizer) {
-        if let action = self.panGestureRecognizerAction {
-            action?()
+        if let action = panGestureRecognizerAction {
+            action?(sender)
         } else {
             print("No action for the pan gesture")
         }
     }
-    
 }
-

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizer.swift
@@ -45,6 +45,8 @@ public extension UIView {
         isUserInteractionEnabled = true
         panGestureRecognizerAction = action
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+        panGestureRecognizer.minimumNumberOfTouches = minimumNumberOfTouches
+        panGestureRecognizer.maximumNumberOfTouches = maximumNumberOfTouches
         addGestureRecognizer(panGestureRecognizer)
     }
     

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,7 +33,7 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
-        _view.gestureLabel.addPanGestureRecognizer {
+        _view.gestureLabel.addPanGestureRecognizer { recognizer in
             print("Label panned!")
         }
     }

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,6 +33,9 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
+        _view.gestureLabel.addPanGestureRecognizer {
+            print("Label panned!")
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizerSpec.swift
@@ -1,0 +1,36 @@
+//
+//  PanRecognizerSpec.swift
+//  WolmoCoreTests
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+import Quick
+import Nimble
+import WolmoCore
+
+public class PanRecognizerSpec: QuickSpec {
+    
+    override public func spec() {
+        
+        describe("#addPanGestureRecognizer(Action:)") {
+            
+            var view: UIView!
+            
+            context("when addPanGestureRecognizer has been called") {
+                beforeEach {
+                    view = UIView()
+                    view.addPanGestureRecognizer { /* No action */ }
+                }
+                
+                it("should have injected a UIPanGestureRecognizer into the view") {
+                    let panRecognizer = view.gestureRecognizers?.first as? UIPanGestureRecognizer
+                    expect(panRecognizer).toNot(beNil())
+                }
+            }
+        }
+    }
+}

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/PanRecognizerSpec.swift
@@ -23,7 +23,9 @@ public class PanRecognizerSpec: QuickSpec {
             context("when addPanGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addPanGestureRecognizer { /* No action */ }
+                    view.addPanGestureRecognizer { recognizer in
+                        //No action
+                    }
                 }
                 
                 it("should have injected a UIPanGestureRecognizer into the view") {


### PR DESCRIPTION
## Summary ##

An extension for `UIView` that allows adding a `UIPanGestureRecognizer` with a closure (instead of using a selector).

#### Example
```Swift
myView.addPanGestureRecognizer { recognizer in
    print("View panned!")
}
```

```Swift
// Panning closure is called only when two or more fingers are used
myView.addPanGestureRecognizer(minimumNumberOfTouches: 2) { recognizer in
    print("View panned!")
}
```

```Swift
// Panning closure is called when two, three or four fingers are used
myView.addPanGestureRecognizer(minimumNumberOfTouches: 2, maximumNumberOfTouches: 4) { recognizer in
    print("View panned!")
}
```