### PR TITLE
Rotation gesture closure

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -15,5 +15,6 @@ ignore:
   - WolmoCore/Extensions/UIKit/UIView/Borders.swift
   - WolmoCore/Extensions/UIKit/UIView/Gradient.swift
   - WolmoCore/Extensions/UIKit/UIView/SafeLayout.swift
+  - WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/*
   - WolmoCore/Extensions/UIKit/UIViewController.swift
   - WolmoCore/Extensions/Animations/*

--- a/WolmoCore.xcodeproj/project.pbxproj
+++ b/WolmoCore.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0CB8BAB6216F835E00C8D6C1 /* ComparableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */; };
 		2D9229821F5D9BF5004F9A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B82058CE1EEF39230002D7D4 /* Assets.xcassets */; };
 		6508BE1B21C7CC3200622EE3 /* TapRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */; };
+		65215B3121D3B2FC0099863F /* RotationRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B3021D3B2FC0099863F /* RotationRecognizer.swift */; };
+		65215B3321D3B3B40099863F /* RotationRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65215B3221D3B3B40099863F /* RotationRecognizerSpec.swift */; };
 		656EDB2121CD3CBE0025DDA0 /* PinchRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */; };
 		656EDB2421CD3DCF0025DDA0 /* PinchRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */; };
 		65A2F8A121C7E2FC001F7190 /* TapRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */; };
@@ -198,6 +200,8 @@
 		0CB8BAB3216F82FF00C8D6C1 /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		0CB8BAB5216F835E00C8D6C1 /* ComparableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparableSpec.swift; sourceTree = "<group>"; };
 		6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizer.swift; sourceTree = "<group>"; };
+		65215B3021D3B2FC0099863F /* RotationRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationRecognizer.swift; sourceTree = "<group>"; };
+		65215B3221D3B3B40099863F /* RotationRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationRecognizerSpec.swift; sourceTree = "<group>"; };
 		656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizer.swift; sourceTree = "<group>"; };
 		656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchRecognizerSpec.swift; sourceTree = "<group>"; };
 		65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRecognizerSpec.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 			children = (
 				6508BE1A21C7CC3200622EE3 /* TapRecognizer.swift */,
 				656EDB2021CD3CBE0025DDA0 /* PinchRecognizer.swift */,
+				65215B3021D3B2FC0099863F /* RotationRecognizer.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -387,6 +392,7 @@
 			children = (
 				65A2F8A021C7E2FC001F7190 /* TapRecognizerSpec.swift */,
 				656EDB2321CD3DCF0025DDA0 /* PinchRecognizerSpec.swift */,
+				65215B3221D3B3B40099863F /* RotationRecognizerSpec.swift */,
 			);
 			path = GestureRecognizers;
 			sourceTree = "<group>";
@@ -893,6 +899,7 @@
 				CE3A9B9C1E607B28005D7E8F /* UIColor.swift in Sources */,
 				CE1DDFDE209A646B007471A0 /* SimpleAnimation.swift in Sources */,
 				CE3A9B9A1E607B28005D7E8F /* UIAlertController.swift in Sources */,
+				65215B3121D3B2FC0099863F /* RotationRecognizer.swift in Sources */,
 				B988B97D1D244D6300824685 /* ConfirmationAlertViewModel.swift in Sources */,
 				CE4F2CBA2135EFF4007BB465 /* SafeLayout.swift in Sources */,
 				CE1DDFDD209A646B007471A0 /* ChainedAnimation.swift in Sources */,
@@ -932,6 +939,7 @@
 				CE1186941EA7A7C600105D6F /* GeneralSpec.swift in Sources */,
 				CEE9BFB91E8986D400D0E65D /* StringSpec.swift in Sources */,
 				CEEC51801EE5EE3400BC41FE /* UILabelSpec.swift in Sources */,
+				65215B3321D3B3B40099863F /* RotationRecognizerSpec.swift in Sources */,
 				CEE9BFCA1E8986DC00D0E65D /* AssociatedObjectSpec.swift in Sources */,
 				CEE9BFBF1E8986D400D0E65D /* UIColorSpec.swift in Sources */,
 				CE1186AC1EA7F67800105D6F /* BundleSpec.swift in Sources */,

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizer.swift
@@ -16,7 +16,7 @@ public extension UIView {
         static var rotationGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
     }
     
-    fileprivate typealias Action = (() -> Void)?
+    fileprivate typealias Action = ((UIRotationGestureRecognizer) -> Void)?
     
     // Set our computed property type to a closure
     fileprivate var rotationGestureRecognizerAction: Action? {
@@ -37,18 +37,18 @@ public extension UIView {
      
      - Parameter action: The closure that will execute when the view is rotated
      */
-    public func addRotationGestureRecognizer(action: (() -> Void)?) {
-        self.isUserInteractionEnabled = true
-        self.rotationGestureRecognizerAction = action
+    public func addRotationGestureRecognizer(action: ((UIRotationGestureRecognizer) -> Void)?) {
+        isUserInteractionEnabled = true
+        rotationGestureRecognizerAction = action
         let rotationGestureRecognizer = UIRotationGestureRecognizer(target: self, action: #selector(handleRotationGesture))
-        self.addGestureRecognizer(rotationGestureRecognizer)
+        addGestureRecognizer(rotationGestureRecognizer)
     }
     
     // Every time the user rotates on the UIView, this function gets called,
     // which triggers the closure we stored
     @objc fileprivate func handleRotationGesture(sender: UIRotationGestureRecognizer) {
-        if let action = self.rotationGestureRecognizerAction {
-            action?()
+        if let action = rotationGestureRecognizerAction {
+            action?(sender)
         } else {
             print("No action for the rotation gesture")
         }

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizer.swift
@@ -1,0 +1,58 @@
+//
+//  RotationRecognizer.swift
+//  WolmoCore
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+public extension UIView {
+    
+    // In order to create computed properties for extensions, we need a key to
+    // store and access the stored property
+    fileprivate struct AssociatedObjectKeys {
+        static var rotationGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
+    }
+    
+    fileprivate typealias Action = (() -> Void)?
+    
+    // Set our computed property type to a closure
+    fileprivate var rotationGestureRecognizerAction: Action? {
+        set {
+            if let newValue = newValue {
+                // Computed properties get stored as associated objects
+                objc_setAssociatedObject(self, &AssociatedObjectKeys.rotationGestureRecognizer, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            }
+        }
+        get {
+            let rotationGestureRecognizerActionInstance = objc_getAssociatedObject(self, &AssociatedObjectKeys.rotationGestureRecognizer) as? Action
+            return rotationGestureRecognizerActionInstance
+        }
+    }
+    
+    /**
+     Adds a rotation gesture recognizer that executes the closure when rotated
+     
+     - Parameter action: The closure that will execute when the view is rotated
+     */
+    public func addRotationGestureRecognizer(action: (() -> Void)?) {
+        self.isUserInteractionEnabled = true
+        self.rotationGestureRecognizerAction = action
+        let rotationGestureRecognizer = UIRotationGestureRecognizer(target: self, action: #selector(handleRotationGesture))
+        self.addGestureRecognizer(rotationGestureRecognizer)
+    }
+    
+    // Every time the user rotates on the UIView, this function gets called,
+    // which triggers the closure we stored
+    @objc fileprivate func handleRotationGesture(sender: UIRotationGestureRecognizer) {
+        if let action = self.rotationGestureRecognizerAction {
+            action?()
+        } else {
+            print("No action for the rotation gesture")
+        }
+    }
+    
+}
+

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,7 +33,7 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
-        _view.gestureLabel.addRotationGestureRecognizer {
+        _view.gestureLabel.addRotationGestureRecognizer { recognizer in
             print("Label rotated!")
         }
     }

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -33,6 +33,9 @@ final internal class ViewController: UIViewController {
         _view.gestureLabel.addPinchGestureRecognizer {
             print("Label pinched!")
         }
+        _view.gestureLabel.addRotationGestureRecognizer {
+            print("Label rotated!")
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizerSpec.swift
@@ -23,7 +23,9 @@ public class RotationRecognizerSpec: QuickSpec {
             context("when addRotationGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addRotationGestureRecognizer { /* No action */ }
+                    view.addRotationGestureRecognizer { recognizer in
+                        // No action
+                    }
                 }
                 
                 it("should have injected a UIRotationGestureRecognizer into the view") {

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GestureRecognizers/RotationRecognizerSpec.swift
@@ -1,0 +1,37 @@
+//
+//  RotationRecognizerSpec.swift
+//  WolmoCoreTests
+//
+//  Created by Gabriel Mazzei on 26/12/2018.
+//  Copyright © 2018 Wolox. All rights reserved.
+//
+
+import Foundation
+
+import Quick
+import Nimble
+import WolmoCore
+
+public class RotationRecognizerSpec: QuickSpec {
+    
+    override public func spec() {
+        
+        describe("#addRotationGestureRecognizer(Action:)") {
+            
+            var view: UIView!
+            
+            context("when addRotationGestureRecognizer has been called") {
+                beforeEach {
+                    view = UIView()
+                    view.addRotationGestureRecognizer { /* No action */ }
+                }
+                
+                it("should have injected a UIRotationGestureRecognizer into the view") {
+                    let rotationRecognizer = view.gestureRecognizers?.first as? UIRotationGestureRecognizer
+                    expect(rotationRecognizer).toNot(beNil())
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary ##

An extension for `UIView` that allows adding a `UIRotationGestureRecognizer` with a closure (instead of using a selector).

#### Example
```Swift
myView.addRotationGestureRecognizer { recognizer in
    print("View rotated!")
}
```