### PR TITLE
Tap and pinch recognizer improvements

### DIFF
--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PinchRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/PinchRecognizer.swift
@@ -16,7 +16,7 @@ public extension UIView {
         static var pinchGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
     }
     
-    fileprivate typealias Action = (() -> Void)?
+    fileprivate typealias Action = ((UIPinchGestureRecognizer) -> Void)?
     
     // Set our computed property type to a closure
     fileprivate var pinchGestureRecognizerAction: Action? {
@@ -37,7 +37,7 @@ public extension UIView {
      
      - Parameter action: The closure that will execute when the view is pinched
      */
-    public func addPinchGestureRecognizer(action: (() -> Void)?) {
+    public func addPinchGestureRecognizer(action: ((UIPinchGestureRecognizer) -> Void)?) {
         isUserInteractionEnabled = true
         pinchGestureRecognizerAction = action
         let pinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handlePinchGesture))
@@ -48,7 +48,7 @@ public extension UIView {
     // which triggers the closure we stored
     @objc fileprivate func handlePinchGesture(sender: UIPinchGestureRecognizer) {
         if let action = pinchGestureRecognizerAction {
-            action?()
+            action?(sender)
         } else {
             print("No action for the pinch gesture")
         }

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
@@ -56,4 +56,3 @@ public extension UIView {
     }
     
 }
-

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/SwipeRecognizer.swift
@@ -60,4 +60,3 @@ public extension UIView {
         }
     }
 }
-

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
@@ -16,7 +16,7 @@ public extension UIView {
         static var tapGestureRecognizer = "MediaViewerAssociatedObjectKey_mediaViewer"
     }
     
-    fileprivate typealias Action = (() -> Void)?
+    fileprivate typealias Action = ((UITapGestureRecognizer) -> Void)?
     
     // Set our computed property type to a closure
     fileprivate var tapGestureRecognizerAction: Action? {
@@ -37,7 +37,7 @@ public extension UIView {
      
      - Parameter action: The closure that will execute when the view is tapped
      */
-    public func addTapGestureRecognizer(action: (() -> Void)?) {
+    public func addTapGestureRecognizer(action: ((UITapGestureRecognizer) -> Void)?) {
         isUserInteractionEnabled = true
         tapGestureRecognizerAction = action
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture))
@@ -48,7 +48,7 @@ public extension UIView {
     // which triggers the closure we stored
     @objc fileprivate func handleTapGesture(sender: UITapGestureRecognizer) {
         if let action = tapGestureRecognizerAction {
-            action?()
+            action?(sender)
         } else {
             print("No action for the tap gesture")
         }

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
@@ -35,12 +35,18 @@ public extension UIView {
     /**
      Adds a tap gesture recognizer that executes the closure when tapped
      
-     - Parameter action: The closure that will execute when the view is tapped
+     - Parameter numberOfTapsRequired:
+     - Parameter numberOfTouchesRequired: The number of taps required to match. Default is 1
+     - Parameter action: The number of fingers required to match. Default is 1
      */
-    public func addTapGestureRecognizer(action: ((UITapGestureRecognizer) -> Void)?) {
+    public func addTapGestureRecognizer(numberOfTapsRequired: Int = 1,
+                                        numberOfTouchesRequired: Int = 1,
+                                        action: ((UITapGestureRecognizer) -> Void)?) {
         isUserInteractionEnabled = true
         tapGestureRecognizerAction = action
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture))
+        tapGestureRecognizer.numberOfTapsRequired = numberOfTapsRequired
+        tapGestureRecognizer.numberOfTouchesRequired = numberOfTouchesRequired
         addGestureRecognizer(tapGestureRecognizer)
     }
     

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/TapRecognizer.swift
@@ -35,8 +35,8 @@ public extension UIView {
     /**
      Adds a tap gesture recognizer that executes the closure when tapped
      
-     - Parameter numberOfTapsRequired:
-     - Parameter numberOfTouchesRequired: The number of taps required to match. Default is 1
+     - Parameter numberOfTapsRequired: The number of taps required to match. Default is 1
+     - Parameter numberOfTouchesRequired: The number of fingers required to match. Default is 1
      - Parameter action: The number of fingers required to match. Default is 1
      */
     public func addTapGestureRecognizer(numberOfTapsRequired: Int = 1,

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -27,10 +27,12 @@ final internal class ViewController: UIViewController {
         
         _view.stringsButton.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         
+        // Screen gestures
         _view.addScreenEdgePanGestureRecognizer(edges: [.left, .right]) { recognizer in
             print("Edge panned!")
         }
         
+        // Label gestures
         _view.gestureLabel.addTapGestureRecognizer(numberOfTapsRequired: 1) { recognizer in
             print("Label tapped!")
         }

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -31,13 +31,13 @@ final internal class ViewController: UIViewController {
             print("Edge panned!")
         }
         
-        _view.gestureLabel.addTapGestureRecognizer {
+        _view.gestureLabel.addTapGestureRecognizer { recognizer in
             print("Label tapped!")
         }
         _view.gestureLabel.addLongPressGestureRecognizer(minimumPressDuration: 1.0) { recognizer in
             print("Label long pressed!")
         }
-        _view.gestureLabel.addPinchGestureRecognizer {
+        _view.gestureLabel.addPinchGestureRecognizer { recognizer in
             print("Label pinched!")
         }
         _view.gestureLabel.addRotationGestureRecognizer { recognizer in

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -31,7 +31,7 @@ final internal class ViewController: UIViewController {
             print("Edge panned!")
         }
         
-        _view.gestureLabel.addTapGestureRecognizer { recognizer in
+        _view.gestureLabel.addTapGestureRecognizer(numberOfTapsRequired: 1) { recognizer in
             print("Label tapped!")
         }
         _view.gestureLabel.addLongPressGestureRecognizer(minimumPressDuration: 1.0) { recognizer in

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/PinchRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/PinchRecognizerSpec.swift
@@ -23,7 +23,9 @@ public class PinchRecognizerSpec: QuickSpec {
             context("when addPinchGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addPinchGestureRecognizer { /* No action */ }
+                    view.addPinchGestureRecognizer { recognizer in
+                        //No action
+                    }
                 }
                 
                 it("should have injected a UIPinchGestureRecognizer into the view") {

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/TapRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/TapRecognizerSpec.swift
@@ -23,7 +23,9 @@ public class TapRecognizerSpec: QuickSpec {
             context("when addTapGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addTapGestureRecognizer { /* No action */ }
+                    view.addTapGestureRecognizer { recognizer in
+                        // No action
+                    }
                 }
                 
                 it("should have injected a UITapGestureRecognizer into the view") {


### PR DESCRIPTION
## Summary ##

Just a fix for tap and pinch recognizers. I've added parameters that were missing and some comments too.

#### Examples
##### Tap
```Swift
myView.addTapGestureRecognizer { recognizer in  // Recognizer is now available in closure
    print("View tapped!")
}
```

```Swift
// New parameters have been added
myView.addTapGestureRecognizer(numberOfTapsRequired: 2, numberOfTouchesRequired: 1) { recognizer in
    print("View tapped twice!")
}
```

##### Pinch
```Swift
myView.addPinchGestureRecognizer { recognizer in  // Recognizer is available here too
    print("View pinched!")
}
```