### PR TITLE
Fix screenEdgePanRecognizer

### DIFF
--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
@@ -34,14 +34,14 @@ public extension UIView {
     
     /**
      Adds a screen-edge-pan gesture recognizer that executes the closure when panned on the edge
-     - Parameter edges: The edges on which this gesture recognizes, relative to the current interface orientation. Default is all edges
+     - Parameter edges: The edge on which this gesture recognizes, relative to the current interface orientation. Default is left edge
      - Parameter action: The closure that will execute when the edge of the view is panned
      */
-    public func addScreenEdgePanGestureRecognizer(edges: UIRectEdge = .all, action: ((UIScreenEdgePanGestureRecognizer) -> Void)?) {
+    public func addScreenEdgePanGestureRecognizer(edge: UIRectEdge, action: ((UIScreenEdgePanGestureRecognizer) -> Void)?) {
         isUserInteractionEnabled = true
         screenEdgePanGestureRecognizerAction = action
         let screenEdgePanGestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePanGesture))
-        screenEdgePanGestureRecognizer.edges = edges
+        screenEdgePanGestureRecognizer.edges = edge
         addGestureRecognizer(screenEdgePanGestureRecognizer)
     }
     

--- a/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/GestureRecognizers/ScreenEdgePanRecognizer.swift
@@ -34,7 +34,7 @@ public extension UIView {
     
     /**
      Adds a screen-edge-pan gesture recognizer that executes the closure when panned on the edge
-     - Parameter edges: The edge on which this gesture recognizes, relative to the current interface orientation. Default is left edge
+     - Parameter edge: The edge on which this gesture recognizes, relative to the current interface orientation.
      - Parameter action: The closure that will execute when the edge of the view is panned
      */
     public func addScreenEdgePanGestureRecognizer(edge: UIRectEdge, action: ((UIScreenEdgePanGestureRecognizer) -> Void)?) {

--- a/WolmoCoreDemo/ViewController.swift
+++ b/WolmoCoreDemo/ViewController.swift
@@ -28,7 +28,7 @@ final internal class ViewController: UIViewController {
         _view.stringsButton.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         
         // Screen gestures
-        _view.addScreenEdgePanGestureRecognizer(edges: [.left, .right]) { recognizer in
+        _view.addScreenEdgePanGestureRecognizer(edge: .left) { recognizer in
             print("Edge panned!")
         }
         

--- a/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/ScreenEdgePanRecognizerSpec.swift
+++ b/WolmoCoreTests/Extensions/UIKit/UIView/GesturesRecognizers/ScreenEdgePanRecognizerSpec.swift
@@ -23,7 +23,7 @@ public class ScreenEdgePanRecognizerSpec: QuickSpec {
             context("when addScreenEdgePanGestureRecognizer has been called") {
                 beforeEach {
                     view = UIView()
-                    view.addScreenEdgePanGestureRecognizer { recognizer in
+                    view.addScreenEdgePanGestureRecognizer(edge: .left) { recognizer in
                         // No action
                     }
                 }


### PR DESCRIPTION
## Summary ##

An extension for UIView that allows adding a UIScreenEdgePanGestureRecognizer with a closure (instead of using a selector). One edge is always required.

##Example##

```
myView.addScreenEdgePanGestureRecognizer(edges: .left) { recognizer in
    print("Edge panned!")
}
```

