### PR TITLE
add rounded borders option and auxiliary function to add multiple bor…

### DIFF
--- a/WolmoCore/Extensions/UIKit/UIView/Borders.swift
+++ b/WolmoCore/Extensions/UIKit/UIView/Borders.swift
@@ -8,16 +8,18 @@
 import UIKit
 
 /**
-    Properties a BorderView has.
+ Properties a BorderView has.
  */
 public struct BorderViewProperties {
     
     public let thickness: Float
     public let color: UIColor
+    public let roundedCorners: Bool
     
-    public init(thickness: Float, color: UIColor) {
+    public init(thickness: Float, color: UIColor, rounded: Bool = false) {
         self.thickness = thickness
         self.color = color
+        self.roundedCorners = rounded
     }
 }
 
@@ -107,6 +109,7 @@ public extension UIView {
              Because of this, it can be used in `loadView()`, `viewDidLoad()` or `viewWillAppear(animated:)`.
              We strongly recommend to work with constraints as a better practice than frames.
      */
+    @discardableResult
     public func add(top border: BorderViewProperties,
                     withLeftOffset left: CGFloat = 0, rightOffset right: CGFloat = 0,
                     layout: LayoutMode = .constraints) -> BorderView {
@@ -128,6 +131,11 @@ public extension UIView {
             addSubview(borderView)
         }
         
+        if border.roundedCorners {
+            borderView.layer.cornerRadius = CGFloat(border.thickness/2)
+            borderView.clipsToBounds = true
+        }
+        
         return borderView
     }
     
@@ -145,6 +153,7 @@ public extension UIView {
              Because of this, it can be used in `loadView()`, `viewDidLoad()` or `viewWillAppear(animated:)`.
              We strongly recommend to work with constraints as a better practice than frames.
      */
+    @discardableResult
     public func add(bottom border: BorderViewProperties,
                     withLeftOffset left: CGFloat = 0, rightOffset right: CGFloat = 0,
                     layout: LayoutMode = .constraints) -> BorderView {
@@ -166,6 +175,11 @@ public extension UIView {
             addSubview(borderView)
         }
         
+        if border.roundedCorners {
+            borderView.layer.cornerRadius = CGFloat(border.thickness/2)
+            borderView.clipsToBounds = true
+        }
+        
         return borderView
     }
     
@@ -183,6 +197,7 @@ public extension UIView {
              Because of this, it can be used in `loadView()`, `viewDidLoad()` or `viewWillAppear(animated:)`.
              We strongly recommend to work with constraints as a better practice than frames.
      */
+    @discardableResult
     public func add(left border: BorderViewProperties,
                     withTopOffset top: CGFloat = 0, bottomOffset bottom: CGFloat = 0,
                     layout: LayoutMode = .constraints) -> BorderView {
@@ -203,6 +218,12 @@ public extension UIView {
             borderView.backgroundColor = border.color
             addSubview(borderView)
         }
+        
+        if border.roundedCorners {
+            borderView.layer.cornerRadius = CGFloat(border.thickness/2)
+            borderView.clipsToBounds = true
+        }
+        
         return borderView
     }
     
@@ -220,6 +241,7 @@ public extension UIView {
              Because of this, it can be used in `loadView()`, `viewDidLoad()` or `viewWillAppear(animated:)`.
              We strongly recommend to work with constraints as a better practice than frames.
      */
+    @discardableResult
     public func add(right border: BorderViewProperties,
                     withTopOffset top: CGFloat = 0, bottomOffset bottom: CGFloat = 0,
                     layout: LayoutMode = .constraints) -> BorderView {
@@ -241,6 +263,11 @@ public extension UIView {
             addSubview(borderView)
         }
         
+        if border.roundedCorners {
+            borderView.layer.cornerRadius = CGFloat(border.thickness/2)
+            borderView.clipsToBounds = true
+        }
+        
         return borderView
     }
 
@@ -251,6 +278,35 @@ public extension UIView {
     public func remove(border: BorderView) {
         if border.superview == self {
             border.removeFromSuperview()
+        }
+    }
+    
+    /**
+     Adds borders to the selected sides of the view, inside the view's bounds.
+     
+     - parameter properties: characteristics of the borders to be added.
+     
+     - parameter positions: the sides of the view where borders will be added.
+     
+     - parameter layout: Enum indicating the layout mode. By default, .constraints.
+     
+     - note: If you decide to use constraints to determine the size, self's frame doesn't need to be final.
+     Because of this, it can be used in `loadView()`, `viewDidLoad()` or `viewWillAppear(animated:)`.
+     We strongly recommend to work with constraints as a better practice than frames.
+     */
+    
+    func addBorders(properties: BorderViewProperties, positions: [BorderPosition], layout: LayoutMode = .constraints) {
+        positions.forEach { position in
+            switch position {
+            case .top:
+                add(top: properties, layout: layout)
+            case .bottom:
+                add(bottom: properties, layout: layout)
+            case .left:
+                add(left: properties, layout: layout)
+            case .right:
+                add(right: properties, layout: layout)
+            }
         }
     }
 

--- a/WolmoCoreDemo/View.swift
+++ b/WolmoCoreDemo/View.swift
@@ -11,9 +11,16 @@ import WolmoCore
 
 final internal class View: UIView, NibLoadable {
     
+    let borderViewProperties = BorderViewProperties(thickness: 4, color: .red, rounded: true)
+    
     @IBOutlet weak var titleLabel: UILabel! {
         didSet {
             titleLabel.fontTextStyle = UIFontTextStyle.headline
+        }
+    }
+    @IBOutlet weak var roundBordersLabel: UILabel! {
+        didSet {
+            roundBordersLabel.addBorders(properties: borderViewProperties, positions: [.left, .right])
         }
     }
     @IBOutlet weak var bodyTextField: UITextField! {

--- a/WolmoCoreDemo/View.xib
+++ b/WolmoCoreDemo/View.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -55,16 +55,24 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Round borders  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QhB-9Z-2sJ">
+                            <rect key="frame" x="122" y="274" width="131" height="21"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="pJn-dR-MNn" firstAttribute="trailing" secondItem="AdN-3F-kMZ" secondAttribute="trailing" constant="20" id="3oq-8w-zoN"/>
                         <constraint firstItem="80Y-qR-yHf" firstAttribute="centerY" secondItem="FcB-gh-c9K" secondAttribute="centerY" id="9Yq-cl-gnd"/>
                         <constraint firstItem="nbm-4U-X48" firstAttribute="leading" secondItem="pJn-dR-MNn" secondAttribute="leading" constant="55" id="JHs-nM-YGt"/>
+                        <constraint firstItem="QhB-9Z-2sJ" firstAttribute="top" secondItem="nbm-4U-X48" secondAttribute="bottom" constant="20" id="OxF-dX-XhJ"/>
                         <constraint firstItem="AdN-3F-kMZ" firstAttribute="top" secondItem="pJn-dR-MNn" secondAttribute="top" constant="20" id="Ph7-cO-Wwd"/>
                         <constraint firstItem="nbm-4U-X48" firstAttribute="top" secondItem="80Y-qR-yHf" secondAttribute="bottom" constant="16" id="SkU-5x-JtQ"/>
                         <constraint firstItem="pJn-dR-MNn" firstAttribute="trailing" secondItem="nbm-4U-X48" secondAttribute="trailing" constant="54" id="a2S-AO-4oi"/>
                         <constraint firstItem="80Y-qR-yHf" firstAttribute="centerX" secondItem="FcB-gh-c9K" secondAttribute="centerX" id="qXl-aD-5il"/>
+                        <constraint firstItem="QhB-9Z-2sJ" firstAttribute="centerX" secondItem="FcB-gh-c9K" secondAttribute="centerX" id="zZQ-6f-bDC"/>
                     </constraints>
                     <viewLayoutGuide key="safeArea" id="pJn-dR-MNn"/>
                 </view>
@@ -89,6 +97,7 @@
                 <outlet property="bodyTextField" destination="kxh-P1-rEG" id="woJ-tq-RSf"/>
                 <outlet property="childContainerView" destination="es8-Vb-lQa" id="4YL-cV-f3j"/>
                 <outlet property="gestureLabel" destination="nbm-4U-X48" id="Qa4-i8-wma"/>
+                <outlet property="roundBordersLabel" destination="QhB-9Z-2sJ" id="tL5-0m-5uI"/>
                 <outlet property="stringsButton" destination="AdN-3F-kMZ" id="L0C-Ra-vpv"/>
                 <outlet property="titleLabel" destination="Nz0-Cq-KJs" id="dFG-iy-fGn"/>
             </connections>


### PR DESCRIPTION

## Summary ##

added option to round border corners, made add() return values discardable and added an auxiliary function to add multiple borders at the same time.

## Screenshots ##

```
let borderViewProperties = BorderViewProperties(thickness: 4, color: .red, rounded: true)
roundBordersLabel.addBorders(properties: borderViewProperties, positions: [.left, .right])
```

![image](https://user-images.githubusercontent.com/37076806/65712378-47aba880-e06d-11e9-9436-7e95a7dcecb4.png)


application example from Natura: 

![image](https://user-images.githubusercontent.com/37076806/65720886-4a16fe00-e07f-11e9-8e28-f68b30e9f739.png)


